### PR TITLE
Issue #5 - Implement BIND-level authentication

### DIFF
--- a/bliss/sle/bin/bliss_sle_bridge.py
+++ b/bliss/sle/bin/bliss_sle_bridge.py
@@ -65,7 +65,10 @@ def process_pdu(raf_mngr):
 
 
 if __name__ == '__main__':
-    raf_mngr = bliss.sle.RAF(hostname='atb-ocio-sspsim.jpl.nasa.gov', port=5100)
+    raf_mngr = bliss.sle.RAF(hostname='atb-ocio-sspsim.jpl.nasa.gov', port=5100,
+                             auth_level="bind",
+                             peer_auth_level="bind",
+                             inst_id="sagr=LSE-SSC.spack=Test.rsl-fg=1.raf=onlc1")
     raf_mngr.connect()
     time.sleep(1)
 

--- a/bliss/sle/bin/bliss_sle_bridge.py
+++ b/bliss/sle/bin/bliss_sle_bridge.py
@@ -69,12 +69,12 @@ if __name__ == '__main__':
     raf_mngr.connect()
     time.sleep(1)
 
-    raf_mngr.bind('sagr=LSE-SSC.spack=Test.rsl-fg=1.raf=onlc1')
+    raf_mngr.bind()
     time.sleep(1)
 
     raf_mngr.start(datetime.datetime(2017, 1, 1), datetime.datetime(2018, 1, 1))
 
-    # tlm_monitor = gevent.spawn(process_pdu, raf_mngr)
+    tlm_monitor = gevent.spawn(process_pdu, raf_mngr)
     gevent.sleep(0)
     log.info('Processing telemetry. Press <Ctrl-c> to terminate connection ...')
     try:
@@ -84,7 +84,7 @@ if __name__ == '__main__':
         pass
     finally:
 
-        # tlm_monitor.kill()
+        tlm_monitor.kill()
 
         raf_mngr.stop()
         time.sleep(1)

--- a/bliss/sle/bin/bliss_sle_bridge.py
+++ b/bliss/sle/bin/bliss_sle_bridge.py
@@ -29,19 +29,21 @@ from pyasn1.codec.native.encoder import encode
 from bliss.core import log
 
 import bliss.sle
+import bliss.sle.frames
 from bliss.sle.pdu.raf import *
 
-def process_pdu():
+def process_pdu(raf_mngr):
     sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
     while True:
         gevent.sleep(0)
-        if bliss.sle.DATA_QUEUE.empty():
+        if raf_mngr._data_queue.empty():
             continue
 
-        hdr, body = bliss.sle.DATA_QUEUE.get()
+        log.info('Empty {}'.format(raf_mngr._data_queue.empty()))
+        pdu = raf_mngr._data_queue.get()
 
         try:
-            decoded_pdu, remainder = bliss.sle.RAF.decode(body)
+            decoded_pdu, remainder = raf_mngr.decode(pdu)
         except pyasn1.error.PyAsn1Error as e:
             log.error('Unable to decode PDU. Skipping ...')
             continue
@@ -57,7 +59,7 @@ def process_pdu():
             # Object does not contain data or data is not initalized. Skipping ...
             continue
 
-        tmf = bliss.sle.TMTransFrame(trans_data)
+        tmf = bliss.sle.frames.TMTransFrame(trans_data)
         log.info('Emitting {} bytes of telemetry to GUI'.format(len(tmf._data[0])))
         sock.sendto(tmf._data[0], ('localhost', 3076))
 
@@ -67,25 +69,26 @@ if __name__ == '__main__':
     raf_mngr.connect()
     time.sleep(1)
 
-    raf_mngr.bind()
+    raf_mngr.bind('sagr=LSE-SSC.spack=Test.rsl-fg=1.raf=onlc1')
     time.sleep(1)
 
-    raf_mngr.send_start_invocation(datetime.datetime(2017, 1, 1), datetime.datetime(2018, 1, 1))
+    raf_mngr.start(datetime.datetime(2017, 1, 1), datetime.datetime(2018, 1, 1))
 
-    tlm_monitor = gevent.spawn(process_pdu)
+    # tlm_monitor = gevent.spawn(process_pdu, raf_mngr)
     gevent.sleep(0)
-    # log.info('Processing telemetry. Press <Ctrl-c> to terminate connection ...')
+    log.info('Processing telemetry. Press <Ctrl-c> to terminate connection ...')
     try:
         while True:
             gevent.sleep(0)
     except:
         pass
+    finally:
 
-    tlm_monitor.kill()
+        # tlm_monitor.kill()
 
-    raf_mngr.stop()
-    time.sleep(1)
+        raf_mngr.stop()
+        time.sleep(1)
 
-    raf_mngr.unbind()
-    time.sleep(1)
+        raf_mngr.unbind()
+        time.sleep(1)
 

--- a/bliss/sle/bin/bliss_sle_bridge.py
+++ b/bliss/sle/bin/bliss_sle_bridge.py
@@ -67,7 +67,6 @@ def process_pdu(raf_mngr):
 if __name__ == '__main__':
     raf_mngr = bliss.sle.RAF(hostname='atb-ocio-sspsim.jpl.nasa.gov', port=5100,
                              auth_level="bind",
-                             peer_auth_level="bind",
                              inst_id="sagr=LSE-SSC.spack=Test.rsl-fg=1.raf=onlc1")
     raf_mngr.connect()
     time.sleep(1)

--- a/bliss/sle/bin/examples/cltu_api_test.py
+++ b/bliss/sle/bin/examples/cltu_api_test.py
@@ -41,8 +41,7 @@ cltu_mngr = bliss.sle.CLTU(
     hostname='atb-ocio-sspsim.jpl.nasa.gov',
     port=5100,
     inst_id='sagr=LSE-SSC.spack=Test.fsl-fg=1.cltu=cltu1',
-    auth_level="bind",
-    peer_auth_level="bind"
+    auth_level="bind"
 )
 
 cltu_mngr.connect()

--- a/bliss/sle/bin/examples/cltu_api_test.py
+++ b/bliss/sle/bin/examples/cltu_api_test.py
@@ -40,7 +40,9 @@ import bliss.sle
 cltu_mngr = bliss.sle.CLTU(
     hostname='atb-ocio-sspsim.jpl.nasa.gov',
     port=5100,
-    inst_id='sagr=LSE-SSC.spack=Test.fsl-fg=1.cltu=cltu1'
+    inst_id='sagr=LSE-SSC.spack=Test.fsl-fg=1.cltu=cltu1',
+    auth_level="bind",
+    peer_auth_level="bind"
 )
 
 cltu_mngr.connect()

--- a/bliss/sle/bin/examples/rcf_api_test.py
+++ b/bliss/sle/bin/examples/rcf_api_test.py
@@ -55,8 +55,7 @@ rcf_mngr = bliss.sle.RCF(
     inst_id='sagr=LSE-SSC.spack=Test.rsl-fg=1.rcf=onlc2',
     spacecraft_id=250,
     trans_frame_ver_num=1,
-    auth_level="bind",
-    peer_auth_level="bind"
+    auth_level="bind"
 )
 
 rcf_mngr.connect()

--- a/bliss/sle/bin/examples/rcf_api_test.py
+++ b/bliss/sle/bin/examples/rcf_api_test.py
@@ -52,7 +52,9 @@ import bliss.sle
 rcf_mngr = bliss.sle.RCF(
     hostname='atb-ocio-sspsim.jpl.nasa.gov',
     port=5100,
-    inst_id='sagr=LSE-SSC.spack=Test.rsl-fg=1.rcf=onlc2'
+    inst_id='sagr=LSE-SSC.spack=Test.rsl-fg=1.rcf=onlc2',
+    spacecraft_id=250,
+    trans_frame_ver_num=1
 )
 
 rcf_mngr.connect()
@@ -65,13 +67,19 @@ start = dt.datetime(2017, 01, 01)
 end = dt.datetime(2018, 01, 01)
 # rcf_mngr.start(start, end, 250, 0, virtual_channel=6)
 rcf_mngr.start(start, end, 250, 0, master_channel=True)
-time.sleep(20)
 
-rcf_mngr.stop()
-time.sleep(2)
+try:
+    while True:
+        time.sleep(0)
+except:
+    pass
+finally:
 
-rcf_mngr.unbind()
-time.sleep(2)
+    rcf_mngr.stop()
+    time.sleep(2)
 
-rcf_mngr.disconnect()
-time.sleep(2)
+    rcf_mngr.unbind()
+    time.sleep(2)
+
+    rcf_mngr.disconnect()
+    time.sleep(2)

--- a/bliss/sle/bin/examples/rcf_api_test.py
+++ b/bliss/sle/bin/examples/rcf_api_test.py
@@ -54,7 +54,9 @@ rcf_mngr = bliss.sle.RCF(
     port=5100,
     inst_id='sagr=LSE-SSC.spack=Test.rsl-fg=1.rcf=onlc2',
     spacecraft_id=250,
-    trans_frame_ver_num=1
+    trans_frame_ver_num=1,
+    auth_level="bind",
+    peer_auth_level="bind"
 )
 
 rcf_mngr.connect()

--- a/bliss/sle/cltu.py
+++ b/bliss/sle/cltu.py
@@ -149,7 +149,7 @@ class CLTU(common.SLE):
         start_invoc = CltuUserToProviderPdu()
 
         if self._credentials:
-            pass
+            start_invoc['cltuStartInvocation']['invokerCredentials']['used'] = self._generate_encoded_credentials()
         else:
             start_invoc['cltuStartInvocation']['invokerCredentials']['unused'] = None
 
@@ -190,7 +190,7 @@ class CLTU(common.SLE):
         pdu = CltuUserToProviderPdu()
 
         if self._credentials:
-            pass
+            pdu['cltuTransferDataInvocation']['invokerCredentials']['used'] = self._generate_encoded_credentials()
         else:
             pdu['cltuTransferDataInvocation']['invokerCredentials']['unused'] = None
 
@@ -238,7 +238,7 @@ class CLTU(common.SLE):
         pdu = CltuUserToProviderPdu()
 
         if self._credentials:
-            pass
+            pdu['cltuScheduleStatusReportInvocation']['invokerCredentials']['used'] = self._generate_encoded_credentials()
         else:
             pdu['cltuScheduleStatusReportInvocation']['invokerCredentials']['unused'] = None
 
@@ -283,7 +283,7 @@ class CLTU(common.SLE):
         pdu = CltuUserToProviderPdu()
 
         if self._credentials:
-            pass
+            pdu['cltuThrowEventInvocation']['invokerCredentials']['used'] = self._generate_encoded_credentials()
         else:
             pdu['cltuThrowEventInvocation']['invokerCredentials']['unused'] = None
 

--- a/bliss/sle/cltu.py
+++ b/bliss/sle/cltu.py
@@ -148,7 +148,7 @@ class CLTU(common.SLE):
         '''
         start_invoc = CltuUserToProviderPdu()
 
-        if self._auth_level in ['all']:
+        if self._auth_level == 'all':
             start_invoc['cltuStartInvocation']['invokerCredentials']['used'] = self.make_credentials()
         else:
             start_invoc['cltuStartInvocation']['invokerCredentials']['unused'] = None
@@ -189,7 +189,7 @@ class CLTU(common.SLE):
         '''
         pdu = CltuUserToProviderPdu()
 
-        if self._auth_level in ['all']:
+        if self._auth_level == 'all':
             pdu['cltuTransferDataInvocation']['invokerCredentials']['used'] = self.make_credentials()
         else:
             pdu['cltuTransferDataInvocation']['invokerCredentials']['unused'] = None
@@ -237,7 +237,7 @@ class CLTU(common.SLE):
         '''
         pdu = CltuUserToProviderPdu()
 
-        if self._auth_level in ['all']:
+        if self._auth_level == 'all':
             pdu['cltuScheduleStatusReportInvocation']['invokerCredentials']['used'] = self.make_credentials()
         else:
             pdu['cltuScheduleStatusReportInvocation']['invokerCredentials']['unused'] = None
@@ -282,7 +282,7 @@ class CLTU(common.SLE):
         '''
         pdu = CltuUserToProviderPdu()
 
-        if self._auth_level in ['all']:
+        if self._auth_level == 'all':
             pdu['cltuThrowEventInvocation']['invokerCredentials']['used'] = self.make_credentials()
         else:
             pdu['cltuThrowEventInvocation']['invokerCredentials']['unused'] = None
@@ -337,7 +337,7 @@ class CLTU(common.SLE):
             return
 
         if 'positive' in result:
-            if self._peer_auth_level in ['bind', 'all']:
+            if self._auth_level in ['bind', 'all']:
                 responder_performer_credentials = pdu['cltuBindReturn']['performerCredentials']['used']
                 if not self._check_return_credentials(responder_performer_credentials, self._responder_id,
                                                   self._peer_password):

--- a/bliss/sle/cltu.py
+++ b/bliss/sle/cltu.py
@@ -327,7 +327,29 @@ class CLTU(common.SLE):
     def _bind_return_handler(self, pdu):
         ''''''
         result = pdu['cltuBindReturn']['result']
+        responder_identifier = pdu['cltuBindReturn']['responderIdentifier']
+
+        # Check that responder_id in the response matches what we know
+        if responder_identifier != self._responder_id:
+            # Invoke PEER-ABORT with unexpected responder id
+            self.peer_abort(1)
+            self._state = 'unbound'
+            return
+
         if 'positive' in result:
+            if self._peer_auth_level in ['bind', 'all']:
+                responder_performer_credentials = pdu['cltuBindReturn']['performerCredentials']['used']
+                if not self._check_return_credentials(responder_performer_credentials, self._responder_id,
+                                                  self._peer_password):
+                    # Authentication failed. Ignore processing the return
+                    bliss.core.log.info('Bind unsuccessful. Authentication failed.')
+                    return
+
+            if self._state == 'ready' or self._state == 'active':
+                # Peer abort with protocol error (3)
+                bliss.core.log.info('Bind unsuccessful. State already in READY or ACTIVE.')
+                self.peer_abort(3)
+
             bliss.core.log.info('Bind successful')
             self._state = 'ready'
         else:

--- a/bliss/sle/cltu.py
+++ b/bliss/sle/cltu.py
@@ -148,8 +148,8 @@ class CLTU(common.SLE):
         '''
         start_invoc = CltuUserToProviderPdu()
 
-        if self._credentials:
-            start_invoc['cltuStartInvocation']['invokerCredentials']['used'] = self._generate_encoded_credentials()
+        if self._auth_level in ['all']:
+            start_invoc['cltuStartInvocation']['invokerCredentials']['used'] = self.make_credentials()
         else:
             start_invoc['cltuStartInvocation']['invokerCredentials']['unused'] = None
 
@@ -189,8 +189,8 @@ class CLTU(common.SLE):
         '''
         pdu = CltuUserToProviderPdu()
 
-        if self._credentials:
-            pdu['cltuTransferDataInvocation']['invokerCredentials']['used'] = self._generate_encoded_credentials()
+        if self._auth_level in ['all']:
+            pdu['cltuTransferDataInvocation']['invokerCredentials']['used'] = self.make_credentials()
         else:
             pdu['cltuTransferDataInvocation']['invokerCredentials']['unused'] = None
 
@@ -237,8 +237,8 @@ class CLTU(common.SLE):
         '''
         pdu = CltuUserToProviderPdu()
 
-        if self._credentials:
-            pdu['cltuScheduleStatusReportInvocation']['invokerCredentials']['used'] = self._generate_encoded_credentials()
+        if self._auth_level in ['all']:
+            pdu['cltuScheduleStatusReportInvocation']['invokerCredentials']['used'] = self.make_credentials()
         else:
             pdu['cltuScheduleStatusReportInvocation']['invokerCredentials']['unused'] = None
 
@@ -282,8 +282,8 @@ class CLTU(common.SLE):
         '''
         pdu = CltuUserToProviderPdu()
 
-        if self._credentials:
-            pdu['cltuThrowEventInvocation']['invokerCredentials']['used'] = self._generate_encoded_credentials()
+        if self._auth_level in ['all']:
+            pdu['cltuThrowEventInvocation']['invokerCredentials']['used'] = self.make_credentials()
         else:
             pdu['cltuThrowEventInvocation']['invokerCredentials']['unused'] = None
 

--- a/bliss/sle/common.py
+++ b/bliss/sle/common.py
@@ -360,7 +360,8 @@ class SLE(object):
         ## This random number for DSN spec
         # random_number = random.randint(0, 42949667295)
 
-        # This random number of SSPSIM
+        # This random number for generic
+        # Taken from https://public.ccsds.org/Pubs/913x1b2.pdf 3.2.3
         random_number = random.randint(0, 2147483647)
 
         hash_input['time'] = credential_time
@@ -376,7 +377,6 @@ class SLE(object):
         isp1_creds['theProtected'] = the_protected
 
         return encode(isp1_creds)
-        # return hashlib.sha1(self._credentials['username'] + '736C6574657365720A')
 
 
 def conn_handler(handler):

--- a/bliss/sle/common.py
+++ b/bliss/sle/common.py
@@ -222,7 +222,7 @@ class SLE(object):
                 The PyASN1 class instance that should be configured with
                 generic SLE attributes, encoded, and sent to SLE.
         '''
-        if self._auth_level in ['all']:
+        if self._auth_level in ['bind', 'all']:
             pdu['invokerCredentials']['used'] = self.make_credentials()
         else:
             pdu['invokerCredentials']['unused'] = None

--- a/bliss/sle/pdu/common.py
+++ b/bliss/sle/pdu/common.py
@@ -19,16 +19,6 @@ from pyasn1.type import univ, char, namedtype, namedval, tag, constraint, useful
 # SLE Service Common Types
 #
 ###############################################################################
-class Credentials(univ.Choice):
-    pass
-
-
-Credentials.componentType = namedtype.NamedTypes(
-    namedtype.NamedType('unused', univ.Null().subtype(implicitTag=tag.Tag(tag.tagClassContext, tag.tagFormatSimple, 0))),
-    namedtype.NamedType('used', univ.OctetString().subtype(subtypeSpec=constraint.ValueSizeConstraint(8, 256)).subtype(implicitTag=tag.Tag(tag.tagClassContext, tag.tagFormatSimple, 1)))
-)
-
-
 class DeliveryMode(univ.Integer):
     pass
 
@@ -329,6 +319,46 @@ LockStatusReport.componentType = namedtype.NamedTypes(
     namedtype.NamedType('carrierLockStatus', CarrierLockStatus()),
     namedtype.NamedType('subcarrierLockStatus', LockStatus()),
     namedtype.NamedType('symbolSyncLockStatus', SymbolLockStatus())
+)
+
+
+class RandomNumber(univ.Integer):
+    pass
+
+
+RandomNumber.subtypeSpec = constraint.ValueRangeConstraint(0, 42949667295)
+
+
+class HashInput(univ.Sequence):
+    pass
+
+
+HashInput.componentType = namedtype.NamedTypes(
+    namedtype.NamedType('time', TimeCCSDS()),
+    namedtype.NamedType('randomNumber', RandomNumber()),
+    namedtype.NamedType('username', char.VisibleString()),
+    namedtype.NamedType('password', univ.OctetString())
+)
+
+
+class ISP1Credentials(univ.Sequence):
+    pass
+
+
+ISP1Credentials.componentType = namedtype.NamedTypes(
+    namedtype.NamedType('time', TimeCCSDS()),
+    namedtype.NamedType('randomNumber', RandomNumber()),
+    namedtype.NamedType('theProtected', univ.OctetString().subtype(subtypeSpec=constraint.ValueSizeConstraint(20, 20)))
+)
+
+
+class Credentials(univ.Choice):
+    pass
+
+
+Credentials.componentType = namedtype.NamedTypes(
+    namedtype.NamedType('unused', univ.Null().subtype(implicitTag=tag.Tag(tag.tagClassContext, tag.tagFormatSimple, 0))),
+    namedtype.NamedType('used', univ.OctetString().subtype(subtypeSpec=constraint.ValueSizeConstraint(8, 256)).subtype(implicitTag=tag.Tag(tag.tagClassContext, tag.tagFormatSimple, 1)))
 )
 
 

--- a/bliss/sle/raf.py
+++ b/bliss/sle/raf.py
@@ -96,7 +96,7 @@ class RAF(common.SLE):
         super(self.__class__, self).__init__(*args, **kwargs)
 
         self._service_type = 'rtnAllFrames'
-        self._version = kwargs.get('version', 4)
+        self._version = kwargs.get('version', 5)
 
         self._handlers['RafBindReturn'].append(self._bind_return_handler)
         self._handlers['RafUnbindReturn'].append(self._unbind_return_handler)
@@ -157,7 +157,7 @@ class RAF(common.SLE):
         '''
         start_invoc = RafUsertoProviderPdu()
 
-        if self._auth_level in ['all']:
+        if self._auth_level == 'all':
             start_invoc['rafStartInvocation']['invokerCredentials']['used'] = self.make_credentials()
         else:
             start_invoc['rafStartInvocation']['invokerCredentials']['unused'] = None
@@ -194,7 +194,7 @@ class RAF(common.SLE):
         '''
         pdu = RafUsertoProviderPdu()
 
-        if self._auth_level in ['all']:
+        if self._auth_level == 'all':
             pdu['rafScheduleStatusReportInvocation']['invokerCredentials']['used'] = self.make_credentials()
         else:
             pdu['rafScheduleStatusReportInvocation']['invokerCredentials']['unused'] = None
@@ -255,7 +255,7 @@ class RAF(common.SLE):
             return
 
         if 'positive' in result:
-            if self._peer_auth_level in ['bind', 'all']:
+            if self._auth_level in ['bind', 'all']:
                 responder_performer_credentials = pdu['rafBindReturn']['performerCredentials']['used']
                 if not self._check_return_credentials(responder_performer_credentials, self._responder_id, self._peer_password):
                     # Authentication failed. Ignore processing the return

--- a/bliss/sle/raf.py
+++ b/bliss/sle/raf.py
@@ -158,7 +158,7 @@ class RAF(common.SLE):
         start_invoc = RafUsertoProviderPdu()
 
         if self._credentials:
-            pass
+            start_invoc['rafStartInvocation']['invokerCredentials']['used'] = self._generate_encoded_credentials()
         else:
             start_invoc['rafStartInvocation']['invokerCredentials']['unused'] = None
 
@@ -166,9 +166,9 @@ class RAF(common.SLE):
         start_time = struct.pack('!HIH', (start_time - common.CCSDS_EPOCH).days, 0, 0)
         stop_time = struct.pack('!HIH', (end_time - common.CCSDS_EPOCH).days, 0, 0)
 
-        start_invoc['rafStartInvocation']['startTime']['known']['ccsdsFormat'] = None
+        # start_invoc['rafStartInvocation']['startTime']['known']['ccsdsFormat'] = None
         start_invoc['rafStartInvocation']['startTime']['known']['ccsdsFormat'] = start_time
-        start_invoc['rafStartInvocation']['stopTime']['known']['ccsdsFormat'] = None
+        # start_invoc['rafStartInvocation']['stopTime']['known']['ccsdsFormat'] = None
         start_invoc['rafStartInvocation']['stopTime']['known']['ccsdsFormat'] = stop_time
         start_invoc['rafStartInvocation']['requestedFrameQuality'] = frame_quality
 
@@ -197,7 +197,7 @@ class RAF(common.SLE):
         pdu = RafUsertoProviderPdu()
 
         if self._credentials:
-            pass
+            pdu['rafScheduleStatusReportInvocation']['invokerCredentials']['used'] = self._generate_encoded_credentials()
         else:
             pdu['rafScheduleStatusReportInvocation']['invokerCredentials']['unused'] = None
 

--- a/bliss/sle/raf.py
+++ b/bliss/sle/raf.py
@@ -257,13 +257,14 @@ class RAF(common.SLE):
         if 'positive' in result:
             if self._peer_auth_level in ['bind', 'all']:
                 responder_performer_credentials = pdu['rafBindReturn']['performerCredentials']['used']
-                if self._check_return_credentials(responder_performer_credentials, self._responder_id, self._peer_password):
+                if not self._check_return_credentials(responder_performer_credentials, self._responder_id, self._peer_password):
                     # Authentication failed. Ignore processing the return
                     bliss.core.log.info('Bind unsuccessful. Authentication failed.')
                     return
 
             if self._state == 'ready' or self._state == 'active':
                 # Peer abort with protocol error (3)
+                bliss.core.log.info('Bind unsuccessful. State already in READY or ACTIVE.')
                 self.peer_abort(3)
 
             bliss.core.log.info('Bind successful')

--- a/bliss/sle/raf.py
+++ b/bliss/sle/raf.py
@@ -166,9 +166,7 @@ class RAF(common.SLE):
         start_time = struct.pack('!HIH', (start_time - common.CCSDS_EPOCH).days, 0, 0)
         stop_time = struct.pack('!HIH', (end_time - common.CCSDS_EPOCH).days, 0, 0)
 
-        # start_invoc['rafStartInvocation']['startTime']['known']['ccsdsFormat'] = None
         start_invoc['rafStartInvocation']['startTime']['known']['ccsdsFormat'] = start_time
-        # start_invoc['rafStartInvocation']['stopTime']['known']['ccsdsFormat'] = None
         start_invoc['rafStartInvocation']['stopTime']['known']['ccsdsFormat'] = stop_time
         start_invoc['rafStartInvocation']['requestedFrameQuality'] = frame_quality
 

--- a/bliss/sle/rcf.py
+++ b/bliss/sle/rcf.py
@@ -206,7 +206,7 @@ class RCF(common.SLE):
 
         start_invoc = RcfUsertoProviderPdu()
 
-        if self._auth_level in ['all']:
+        if self._auth_level == 'all':
             start_invoc['rcfStartInvocation']['invokerCredentials']['used'] = self.make_credentials()
         else:
             start_invoc['rcfStartInvocation']['invokerCredentials']['unused'] = None
@@ -253,7 +253,7 @@ class RCF(common.SLE):
         '''
         pdu = RcfUsertoProviderPdu()
 
-        if self._auth_level in ['all']:
+        if self._auth_level == 'all':
             pdu['rcfScheduleStatusReportInvocation']['invokerCredentials']['used'] = self.make_credentials()
         else:
             pdu['rcfScheduleStatusReportInvocation']['invokerCredentials']['unused'] = None
@@ -329,7 +329,7 @@ class RCF(common.SLE):
             return
 
         if 'positive' in result:
-            if self._peer_auth_level in ['bind', 'all']:
+            if self._auth_level in ['bind', 'all']:
                 responder_performer_credentials = pdu['rcfBindReturn']['performerCredentials']['used']
                 if not self._check_return_credentials(responder_performer_credentials, self._responder_id,
                                                   self._peer_password):

--- a/bliss/sle/rcf.py
+++ b/bliss/sle/rcf.py
@@ -207,7 +207,7 @@ class RCF(common.SLE):
         start_invoc = RcfUsertoProviderPdu()
 
         if self._credentials:
-            pass
+            start_invoc['rcfStartInvocation']['invokerCredentials']['used'] = self._generate_encoded_credentials()
         else:
             start_invoc['rcfStartInvocation']['invokerCredentials']['unused'] = None
 
@@ -215,9 +215,7 @@ class RCF(common.SLE):
         start_time = struct.pack('!HIH', (start_time - common.CCSDS_EPOCH).days, 0, 0)
         stop_time = struct.pack('!HIH', (end_time - common.CCSDS_EPOCH).days, 0, 0)
 
-        start_invoc['rcfStartInvocation']['startTime']['known']['ccsdsFormat'] = None
         start_invoc['rcfStartInvocation']['startTime']['known']['ccsdsFormat'] = start_time
-        start_invoc['rcfStartInvocation']['stopTime']['known']['ccsdsFormat'] = None
         start_invoc['rcfStartInvocation']['stopTime']['known']['ccsdsFormat'] = stop_time
 
         req_gvcid = GvcId()
@@ -256,7 +254,7 @@ class RCF(common.SLE):
         pdu = RcfUsertoProviderPdu()
 
         if self._credentials:
-            pass
+            pdu['rcfScheduleStatusReportInvocation']['invokerCredentials']['used'] = self._generate_encoded_credentials()
         else:
             pdu['rcfScheduleStatusReportInvocation']['invokerCredentials']['unused'] = None
 

--- a/bliss/sle/rcf.py
+++ b/bliss/sle/rcf.py
@@ -319,7 +319,29 @@ class RCF(common.SLE):
     def _bind_return_handler(self, pdu):
         ''''''
         result = pdu['rcfBindReturn']['result']
+        responder_identifier = pdu['rcfBindReturn']['responderIdentifier']
+
+        # Check that responder_id in the response matches what we know
+        if responder_identifier != self._responder_id:
+            # Invoke PEER-ABORT with unexpected responder id
+            self.peer_abort(1)
+            self._state = 'unbound'
+            return
+
         if 'positive' in result:
+            if self._peer_auth_level in ['bind', 'all']:
+                responder_performer_credentials = pdu['rcfBindReturn']['performerCredentials']['used']
+                if not self._check_return_credentials(responder_performer_credentials, self._responder_id,
+                                                  self._peer_password):
+                    # Authentication failed. Ignore processing the return
+                    bliss.core.log.info('Bind unsuccessful. Authentication failed.')
+                    return
+
+            if self._state == 'ready' or self._state == 'active':
+                # Peer abort with protocol error (3)
+                bliss.core.log.info('Bind unsuccessful. State already in READY or ACTIVE.')
+                self.peer_abort(3)
+
             bliss.core.log.info('Bind successful')
             self._state = 'ready'
         else:

--- a/bliss/sle/rcf.py
+++ b/bliss/sle/rcf.py
@@ -206,8 +206,8 @@ class RCF(common.SLE):
 
         start_invoc = RcfUsertoProviderPdu()
 
-        if self._credentials:
-            start_invoc['rcfStartInvocation']['invokerCredentials']['used'] = self._generate_encoded_credentials()
+        if self._auth_level in ['all']:
+            start_invoc['rcfStartInvocation']['invokerCredentials']['used'] = self.make_credentials()
         else:
             start_invoc['rcfStartInvocation']['invokerCredentials']['unused'] = None
 
@@ -253,8 +253,8 @@ class RCF(common.SLE):
         '''
         pdu = RcfUsertoProviderPdu()
 
-        if self._credentials:
-            pdu['rcfScheduleStatusReportInvocation']['invokerCredentials']['used'] = self._generate_encoded_credentials()
+        if self._auth_level in ['all']:
+            pdu['rcfScheduleStatusReportInvocation']['invokerCredentials']['used'] = self.make_credentials()
         else:
             pdu['rcfScheduleStatusReportInvocation']['invokerCredentials']['unused'] = None
 

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -24,9 +24,10 @@ default:
 
     dsn:
         sle:
-            credentials:
-                username: user
-                password: pw
+            initiator_id: uname
+            password: pw
+            responder_id: uname
+            peer_password: pw
         cfdp:
             mib:
                 path: ../tmp/mib

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -23,6 +23,10 @@ default:
         filename: bsc.yaml
 
     dsn:
+        sle:
+            credentials:
+                username: user
+                password: pw
         cfdp:
             mib:
                 path: ../tmp/mib


### PR DESCRIPTION
Resolves #5

- Adds ans.1 types for ISP1Credentials and HashInput
- Updates `config.yaml` to include credential/auth level config
- Updates BIND logic to do credentials for auth levels BIND/ALL 
- Update other references to where credential logic should happen (but return handler logic will need to be implemented for auth level ALL)
- Fix examples and update with auth level config
