### PR TITLE
Issue #34 - Fix broken TravisCI build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,9 +7,10 @@ branches:
     - master
 
 env:
-  - AIT_CONFIG: ${TRAVIS_BUILD_DIR}/data/config/config.yaml
+  #  - AIT_CONFIG: ${TRAVIS_BUILD_DIR}/config/config.yaml
+  - BLISS_CONFIG: ${TRAVIS_BUILD_DIR}/config/config.yaml
 
 install:
   - pip install .[tests]
 
-script: nosetests
+script: python setup.py nosetests


### PR DESCRIPTION
Update config env vars to set both AIT_CONFIG and BLISS_CONFIG until we
switch over to AIT Core in DSN repo. Technically these aren't both
needed, and the AIT_CONFIG value doesn't work, but it's a good reminder of
the changes we need to make.

Update config paths to proper DSN repo config paths. Previously the core
config path structure was being used.

Update test run script to use `python setup.py nosetests` so tests don't
fail to properly import libraries.