### PR TITLE
CFDP Class 2 NAK procedures

### DIFF
--- a/ait/dsn/bin/ait_cfdp_start_receiver
+++ b/ait/dsn/bin/ait_cfdp_start_receiver
@@ -14,22 +14,22 @@
 # or other export authority as may be required before exporting such
 # information to foreign countries or providing access to foreign persons.
 
-import bliss.cfdp
+import ait.cfdp
 import gevent
 import traceback
 
-import bliss.core.log
+import ait.core.log
 
 
 if __name__ == '__main__':
 
-    cfdp = bliss.cfdp.CFDP(2)
+    cfdp = ait.cfdp.CFDP(2)
     try:
         # cfdp.connect(('127.0.0.1', 8002))
         # # Set the address of the counterpart
         # cfdp.mib.set_remote('1', 'ut_address', ('127.0.0.1', 8001))
         while True:
-            # bliss.core.log.info('Sleeping...')
+            # ait.core.log.info('Sleeping...')
             gevent.sleep(1)
     except KeyboardInterrupt:
         print "Disconnecting..."

--- a/ait/dsn/cfdp/cfdp.py
+++ b/ait/dsn/cfdp/cfdp.py
@@ -45,7 +45,7 @@ class CFDP(object):
     incoming_pdu_queue = gevent.queue.Queue()
 
     def __init__(self, entity_id, *args, **kwargs):
-        # State machines for current transactions (basically just transactions. Can be Class 1 or 2 sender or receiver
+        # State machines for current transactions (basically just transactions. Can be Class 1 or 2 sender or sender
         self._machines = {}
         # temporary handler for getting pdus from directory and putting into incoming queue
         self._read_pdu_handler = gevent.spawn(read_pdus, self)
@@ -377,21 +377,21 @@ def transaction_handler(instance):
                         and machine.inactivity_timer.expired():
                     machine.inactivity_timer.cancel()
                     machine.update_state(Event.E27_INACTIVITY_TIMER_EXPIRED)
-                elif hasattr(machine, 'nak_timer') and machine.nak_timer is not None \
+                if hasattr(machine, 'nak_timer') and machine.nak_timer is not None \
                         and machine.nak_timer.expired():
                     machine.nak_timer.cancel()
                     machine.update_state(Event.E26_NAK_TIMER_EXPIRED)
-                elif hasattr(machine, 'ack_timer') and machine.ack_timer is not None \
+                if hasattr(machine, 'ack_timer') and machine.ack_timer is not None \
                         and machine.ack_timer.expired():
                     machine.ack_timer.cancel()
                     machine.update_state(Event.E25_ACK_TIMER_EXPIRED)
-                elif machine.role != Role.CLASS_1_RECEIVER:
+                if machine.role != Role.CLASS_1_RECEIVER:
                     # Let 1 file directive go per machine. R1 doesn't output PDUs
                     machine.update_state(Event.E0_SEND_FILE_DIRECTIVE)
 
             # Loop again to send file data
             for trans_num, machine in instance._machines.items():
-                if machine.role == Role.CLASS_1_SENDER:
+                if machine.role == Role.CLASS_1_SENDER or machine.role == Role.CLASS_2_SENDER:
                     machine.update_state(Event.E1_SEND_FILE_DATA)
         except Exception as e:
             ait.core.log.warn("EXCEPTION: " + e.message)

--- a/ait/dsn/cfdp/cfdp.py
+++ b/ait/dsn/cfdp/cfdp.py
@@ -22,7 +22,7 @@ import gevent.queue
 import gevent.socket
 
 from ait.dsn.cfdp.events import Event
-from ait.dsn.cfdp.machines import Receiver1, Sender1
+from ait.dsn.cfdp.machines import Receiver1, Sender1, Sender2, Receiver2
 from ait.dsn.cfdp.mib import MIB
 from ait.dsn.cfdp.pdu import make_pdu_from_bytes, Header
 from ait.dsn.cfdp.primitives import RequestType, TransmissionMode, FileDirective, Role, ConditionCode
@@ -136,10 +136,6 @@ class CFDP(object):
         if transmission_mode is None:
             transmission_mode = self.mib.transmission_mode(destination_id)
 
-        if transmission_mode == TransmissionMode.ACK:
-            # TODO raise invalid transmission mode since we don't support ACK right now
-            pass
-
         # Create a `Request` which contains all the parameters for a Put.request
         # This is passed to the machine to progress the state
         request = create_request_from_type(RequestType.PUT_REQUEST,
@@ -147,10 +143,10 @@ class CFDP(object):
                                            source_path=source_path,
                                            destination_path=destination_path,
                                            transmission_mode=transmission_mode)
-        # if transmission_mode == TransmissionMode.ACK:
-        #     machine = Sender2(self, transaction_num, request=request)
-        # else:
-        machine = Sender1(self, transaction_num)
+        if transmission_mode == TransmissionMode.ACK:
+            machine = Sender2(self, transaction_num)
+        else:
+            machine = Sender1(self, transaction_num)
         # Send the Put.request `Request` to the newly created machine
         # This is where the rest of the Put request procedures are done
         machine.update_state(event=Event.E30_RECEIVED_PUT_REQUEST, request=request)
@@ -273,11 +269,14 @@ def receiving_handler(instance):
                     # If machine doesn't exist, create a machine for this transaction
                     transmission_mode = pdu.header.transmission_mode
                     if machine is None:
-                        # if transmission_mode == TransmissionMode.NO_ACK:
-                        machine = Receiver1(instance, transaction_num)
+                        if transmission_mode == TransmissionMode.ACK:
+                            machine = Receiver2(instance, transaction_num)
+                        else:
+                            machine = Receiver1(instance, transaction_num)
                         instance._machines[transaction_num] = machine
 
                     machine.update_state(Event.E10_RECEIVED_METADATA_PDU, pdu=pdu)
+
                 elif pdu.file_directive_code == FileDirective.EOF:
                     if machine is None:
                         ait.core.log.info('Ignoring EOF for transaction that doesn\'t exist: {}'
@@ -290,6 +289,7 @@ def receiving_handler(instance):
                             machine.update_state(Event.E12_RECEIVED_EOF_NO_ERROR_PDU, pdu=pdu)
                         else:
                             ait.core.log.warn('Received EOF with strang condition code: {}'.format(pdu.condition_code))
+
                 elif pdu.file_directive_code == FileDirective.NAK:
                     if machine is None:
                         ait.core.log.info('Ignoring NAK for transaction that doesn\'t exist: {}'

--- a/ait/dsn/cfdp/machines/__init__.py
+++ b/ait/dsn/cfdp/machines/__init__.py
@@ -14,3 +14,5 @@
 
 from sender1 import Sender1
 from receiver1 import Receiver1
+from sender2 import Sender2
+from receiver2 import Receiver2

--- a/ait/dsn/cfdp/machines/machine.py
+++ b/ait/dsn/cfdp/machines/machine.py
@@ -72,7 +72,6 @@ class Transaction(object):
         self.final_status = None
         self.finished = False
         self.frozen = False
-        self.is_metadata_received = False
         self.metadata = None
         self.other_entity_id = None  # entity ID of other end of Tx
         self.start_time = None
@@ -113,6 +112,7 @@ class Machine(object):
         self.eof = None
 
         # State machine flags
+        self.md_received = False
         self.pdu_received = False
         self.put_request_received = False
         self.eof_received = False
@@ -129,6 +129,8 @@ class Machine(object):
         self.inactivity_timer = None
         self.ack_timer = None
         self.nak_timer = None
+        self.ack_count = 0
+        self.nak_count = 0
 
     def _indication_handler(self, indication_type, *args, **kwargs):
         """
@@ -252,7 +254,7 @@ class Machine(object):
         self.cancel_timers()
 
         self.transaction.finished = True
-        if self.role == Role.CLASS_1_RECEIVER and not self.transaction.is_metadata_received:
+        if self.role == Role.CLASS_1_RECEIVER and not self.md_received:
             self.transaction.final_status = FinalStatus.FINAL_STATUS_NO_METADATA
         elif self.transaction.cancelled:
             self.transaction.final_status = FinalStatus.FINAL_STATUS_CANCELLED

--- a/ait/dsn/cfdp/machines/sender1.py
+++ b/ait/dsn/cfdp/machines/sender1.py
@@ -99,12 +99,17 @@ class Sender1(Machine):
         )
         return self.eof
 
-    def make_fd_pdu(self):
+    def make_fd_pdu(self, offset=None, length=None):
+        if self.file is None:
+            # TODO error for if file is not open
+            return self.fault_handler(ConditionCode.FILESTORE_REJECTION)
+
         file_chunk_size = self.kernel.mib.maximum_file_segment_length(self.transaction.entity_id)
-        offset = 0
-        data_chunk = None
-        if self.file is not None:
+        if offset is None:
             offset = self.file.tell()
+        if length is not None:
+            data_chunk = self.file.read(length)
+        else:
             data_chunk = self.file.read(file_chunk_size)
         if not data_chunk:
             # FIXME to be more accurate of an error

--- a/ait/dsn/cfdp/machines/sender1.py
+++ b/ait/dsn/cfdp/machines/sender1.py
@@ -105,8 +105,12 @@ class Sender1(Machine):
             return self.fault_handler(ConditionCode.FILESTORE_REJECTION)
 
         file_chunk_size = self.kernel.mib.maximum_file_segment_length(self.transaction.entity_id)
+        ait.core.log.debug("Sender {0}: Offset, length {1} {2}"
+                          .format(self.transaction.entity_id, offset, length))
         if offset is None:
             offset = self.file.tell()
+        else:
+            offset = self.file.seek(offset)
         if length is not None:
             data_chunk = self.file.read(length)
         else:
@@ -190,7 +194,6 @@ class Sender1(Machine):
         # Make MD PDU from request and queue it up for sending
         self.make_metadata_pdu_from_request(request)
         self.is_md_outgoing = True
-
         self.handle_file_transfer(outgoing_directory)
 
     def update_state(self, event=None, pdu=None, request=None):

--- a/ait/dsn/cfdp/machines/sender2.py
+++ b/ait/dsn/cfdp/machines/sender2.py
@@ -12,14 +12,10 @@
 # or other export authority as may be required before exporting such
 # information to foreign countries or providing access to foreign persons.
 
-import copy
-import os
 import gevent.queue
 
 from ait.dsn.cfdp.events import Event
-from ait.dsn.cfdp.pdu import Metadata, Header, FileData, EOF
 from ait.dsn.cfdp.primitives import Role, ConditionCode, IndicationType
-from ait.dsn.cfdp.util import string_length_in_bytes, calc_file_size, check_file_structure, calc_checksum
 from ait.dsn.cfdp.timer import Timer
 from sender1 import Sender1
 
@@ -90,6 +86,76 @@ class Sender2(Sender1):
             # Only event in S1 with defined action is receiving a put request
             if event == Event.E30_RECEIVED_PUT_REQUEST:
                 self.handle_put_request(request)
+
+            elif event == Event.E2_ABANDON_TRANSACTION:
+                # E2: N/A
+                return
+
+            elif event == Event.E3_NOTICE_OF_CANCELLATION:
+                # E3 : N/A
+                return
+
+            elif event == Event.E4_NOTICE_OF_SUSPENSION:
+                # E4 : N/A
+                return
+
+            elif event == Event.E5_SUSPEND_TIMERS:
+                # E5 : N/A
+                return
+
+            elif event == Event.E6_RESUME_TIMERS:
+                # E6 : N/A
+                return
+
+            elif event == Event.E14_RECEIVED_ACK_EOF_CANCEL_PDU or event == Event.E14_RECEIVED_ACK_EOF_NO_ERROR_PDU:
+                # E14
+                return
+
+            elif event == Event.E15_RECEIVED_NAK_PDU:
+                # E15 : N/A
+                return
+
+            elif event == Event.E17_RECEIVED_FINISHED_CANCEL_PDU:
+                # E17
+                return
+
+            elif event == Event.E25_ACK_TIMER_EXPIRED:
+                # E25
+                return
+
+            elif event == Event.E31_RECEIVED_SUSPEND_REQUEST:
+                # E31: N/A
+                return
+
+            elif event == Event.E32_RECEIVED_RESUME_REQUEST:
+                # E32: N/A
+                return
+
+            elif event == Event.E33_RECEIVED_CANCEL_REQUEST:
+                # E33: N/A
+                return
+
+            elif event == Event.E34_RECEIVED_REPORT_REQUEST:
+                # E34: N/A
+                return
+
+            elif event == Event.E40_RECEIVED_FREEZE_REQUEST:
+                # E40: N/A
+                return
+
+            elif event == Event.E41_RECEIVED_THAW_REQUEST:
+                # #41: N/A
+                return
+
+            elif event == Event.E1_SEND_FILE_DATA:
+                # E1
+                return
+
+            elif event == Event.E4_NOTICE_OF_SUSPENSION:
+                return
+
+            elif event == Event.E17_RECEIVED_FINISHED_CANCEL_PDU:
+                return
 
             else:
                 ait.core.log.debug("Sender {0}: Ignoring received event {1}".format(self.transaction.entity_id, event))

--- a/ait/dsn/cfdp/mib.py
+++ b/ait/dsn/cfdp/mib.py
@@ -47,7 +47,7 @@ remote_mib_fields = {
     'ack_timeout': 10,                      #
     'inactivity_timeout': 30,               # inactivity time limit for a transaction
     'nak_timeout': 10,                      # time interval for NAK
-    'nak_limit': 3,                        # limit on number of NAK expirations
+    'nak_limit': 10,                        # limit on number of NAK expirations
     'maximum_file_segment_length': 4096,      # in octets
     'transmission_mode': TransmissionMode.NO_ACK,
     'crc_required_on_transmission': False,

--- a/ait/dsn/cfdp/mib.py
+++ b/ait/dsn/cfdp/mib.py
@@ -46,7 +46,7 @@ remote_mib_fields = {
     'ack_limit': 3,                        # positive ack count limit (number of expirations)
     'ack_timeout': 10,                      #
     'inactivity_timeout': 30,               # inactivity time limit for a transaction
-    'nak_timeout': 10,                      # time interval for NAK
+    'nak_timeout': 5,                      # time interval for NAK
     'nak_limit': 10,                        # limit on number of NAK expirations
     'maximum_file_segment_length': 4096,      # in octets
     'transmission_mode': TransmissionMode.NO_ACK,

--- a/ait/dsn/cfdp/pdu/nak.py
+++ b/ait/dsn/cfdp/pdu/nak.py
@@ -42,7 +42,21 @@ class NAK(PDU):
         bytes.append(int(byte_3[16:24], 2))
         bytes.append(int(byte_3[24:32], 2))
 
-        # TODO N x 64 segment requests
+        # 32 * N segment requests
+        for segment in self.segment_requests:
+            start = segment[0]
+            start_byte = format(start, '>032b')
+            bytes.append(int(start_byte[0:8], 2))
+            bytes.append(int(start_byte[8:16], 2))
+            bytes.append(int(start_byte[16:24], 2))
+            bytes.append(int(start_byte[24:32], 2))
+
+            end = segment[1]
+            end_byte = format(end, '>032b')
+            bytes.append(int(end_byte[0:8], 2))
+            bytes.append(int(end_byte[8:16], 2))
+            bytes.append(int(end_byte[16:24], 2))
+            bytes.append(int(end_byte[24:32], 2))
 
         if self.header:
             header_bytes = self.header.to_bytes()
@@ -76,9 +90,21 @@ class NAK(PDU):
                            + format(pdu_bytes[8], '>08b')
         end_of_scope = int(end_scope_bin, 2)
 
-        # TODO N x 64 Segment requests
+        # 32 * N segment requests
+        segments = []
+        for index in range(9, len(pdu_bytes), 8):
+            start = int(format(pdu_bytes[index], '>08b') \
+                           + format(pdu_bytes[index + 1], '>08b') \
+                           + format(pdu_bytes[index + 2], '>08b') \
+                           + format(pdu_bytes[index + 3], '>08b'), 2)
+            end = int(format(pdu_bytes[index + 4], '>08b') \
+                    + format(pdu_bytes[index + 5], '>08b') \
+                    + format(pdu_bytes[index + 6], '>08b') \
+                    + format(pdu_bytes[index + 7], '>08b'), 2)
+            segments.append((start, end))
 
         return NAK(
             start_of_scope=start_of_scope,
-            end_of_scope=end_of_scope
+            end_of_scope=end_of_scope,
+            segment_requests=segments
         )

--- a/ait/dsn/cfdp/test/pdu_test.py
+++ b/ait/dsn/cfdp/test/pdu_test.py
@@ -294,6 +294,7 @@ class NAKTest(unittest.TestCase):
         nak = {
             'start_of_scope': 2343,
             'end_of_scope': 2346,
+            'segment_requests': [(0, 9), (12, 20)]
         }
         self.fixture = NAK(**nak)
         self.fixture.header = Header(**hdr)
@@ -311,6 +312,7 @@ class NAKTest(unittest.TestCase):
 
         self.assertEqual(self.fixture.start_of_scope, pdu_object.start_of_scope)
         self.assertEqual(self.fixture.end_of_scope, pdu_object.end_of_scope)
+        self.assertItemsEqual(self.fixture.segment_requests, pdu_object.segment_requests)
 
     def test_nak_read_write(self):
         """Write NAK to file, then read back to object"""
@@ -330,6 +332,7 @@ class NAKTest(unittest.TestCase):
         self.assertNotEqual(pdu_object, None)
         self.assertEqual(self.fixture.start_of_scope, pdu_object.start_of_scope)
         self.assertEqual(self.fixture.end_of_scope, pdu_object.end_of_scope)
+        self.assertItemsEqual(self.fixture.segment_requests, pdu_object.segment_requests)
 
 
 class FinishedTest(unittest.TestCase):

--- a/ait/dsn/cfdp/test/receiver_nak_test.py
+++ b/ait/dsn/cfdp/test/receiver_nak_test.py
@@ -1,0 +1,174 @@
+# Advanced Multi-Mission Operations System (AMMOS) Instrument Toolkit (AIT)
+# Bespoke Link to Instruments and Small Satellites (BLISS)
+#
+# Copyright 2018, by the California Institute of Technology. ALL RIGHTS
+# RESERVED. United States Government Sponsorship acknowledged. Any
+# commercial use must be negotiated with the Office of Technology Transfer
+# at the California Institute of Technology.
+#
+# This software may be subject to U.S. export control laws. By accepting
+# this software, the user agrees to comply with all applicable U.S. export
+# laws and regulations. User has the responsibility to obtain export licenses,
+# or other export authority as may be required before exporting such
+# information to foreign countries or providing access to foreign persons.
+
+import os
+import glob
+import shutil
+import unittest
+import copy
+from functools import partial
+import filecmp
+
+import gevent
+import traceback
+
+import ait.core
+import ait.core.log
+from ait.dsn.cfdp import CFDP
+from ait.dsn.cfdp.events import Event
+from ait.dsn.cfdp.machines import Receiver2
+from ait.dsn.cfdp.cfdp import read_incoming_pdu, write_outgoing_pdu
+from ait.dsn.cfdp.util import string_length_in_bytes, calc_file_size, check_file_structure, calc_checksum
+from ait.dsn.cfdp.pdu import Header, Metadata, EOF, FileData, ACK, NAK, Finished
+from ait.dsn.cfdp.primitives import ConditionCode, TransactionStatus, DirectiveCode, FinishedPduFileStatus, TransmissionMode
+
+
+TEST_DIRECTORY = os.path.join(os.path.dirname(__file__), '.pdusink')
+def setUpModule():
+    if not os.path.exists(TEST_DIRECTORY):
+        os.makedirs(TEST_DIRECTORY)
+
+def tearDownModule():
+    if os.path.exists(TEST_DIRECTORY):
+        shutil.rmtree(TEST_DIRECTORY)
+
+
+class HeaderTest(unittest.TestCase):
+
+    def setUp(self):
+        self.cfdp = CFDP(2)
+        self.receiver = Receiver2(self.cfdp, 1)
+
+        self.source_path = 'medium.txt'
+        self.destination_path = 'test/path/med.txt'
+        self.full_source_path = os.path.join(self.cfdp._data_paths['outgoing'], self.source_path)
+        self.full_dest_path = os.path.join(self.cfdp._data_paths['incoming'], self.destination_path)
+
+        # CREATE PDUS
+        self.pdus = []
+
+        # MAKE HEADER
+        self.header = Header()
+        self.header.direction = Header.TOWARDS_RECEIVER
+        self.header.entity_ids_length = 8
+        self.header.transaction_id_length = 8
+        self.header.source_entity_id = 1
+        self.header.transaction_id = 1
+        self.header.destination_entity_id = 2
+        self.header.transmission_mode = TransmissionMode.ACK
+
+        # MAKE METADATA
+        data_field_length_octets = 6
+        # Each of these is +1 for 8 bit length field
+        data_field_length_octets += (string_length_in_bytes(self.source_path) + 1)
+        data_field_length_octets += (string_length_in_bytes(self.destination_path) + 1)
+        self.header.pdu_data_field_length = data_field_length_octets
+
+        file_size = calc_file_size(self.full_source_path)
+
+        # Copy header
+        header = copy.copy(self.header)
+        header.pdu_type = Header.FILE_DIRECTIVE_PDU
+        self.metadata = Metadata(
+            header=header,
+            source_path=self.source_path,
+            destination_path=self.destination_path,
+            file_size=file_size)
+
+        # MAKE FILE DATA PDUS
+        with open(self.full_source_path, 'rb') as file:
+            for chunk in iter(partial(file.read, 1024), ''):
+                offset = file.tell() - len(chunk)
+                header = copy.copy(self.header)
+                header.pdu_type = Header.FILE_DATA_PDU
+
+                # Calculate pdu data field length for header
+                data_field_length_octets = 4
+                # Get file data size
+                data_field_length_octets += len(chunk)
+                header.pdu_data_field_length = data_field_length_octets
+
+                fd = FileData(
+                    header=header,
+                    segment_offset=offset,
+                    data=chunk)
+                self.pdus.append(fd)
+
+        # MAKE EOF
+        header = copy.copy(self.header)
+        header.pdu_type = Header.FILE_DIRECTIVE_PDU
+        data_field_length_octets = 10
+        header.pdu_data_field_length = data_field_length_octets
+
+        self.eof = EOF(
+            header=header,
+            condition_code=ConditionCode.NO_ERROR,
+            file_checksum=calc_checksum(self.full_source_path),
+            file_size=self.metadata.file_size
+        )
+
+    def tearDown(self):
+        self.fixture = None
+        for f in glob.glob(os.path.join(TEST_DIRECTORY, '*')):
+            os.remove(f)
+
+        self.cfdp.disconnect()
+
+        # clear data from datasink
+        if os.path.exists(self.cfdp._data_paths['incoming']):
+            shutil.rmtree(self.cfdp._data_paths['incoming'])
+            os.makedirs(self.cfdp._data_paths['incoming'])
+
+        if os.path.exists(self.cfdp._data_paths['tempfiles']):
+            shutil.rmtree(self.cfdp._data_paths['tempfiles'])
+            os.makedirs(self.cfdp._data_paths['tempfiles'])
+
+        if os.path.exists(self.cfdp._data_paths['pdusink']):
+            shutil.rmtree(self.cfdp._data_paths['pdusink'])
+            os.makedirs(self.cfdp._data_paths['pdusink'])
+
+    def test_receiver2_got_all_file_data(self):
+        """Ensure that receiver nak list is empty when all file data is received and that the source and destination files are equal"""
+
+        self.receiver.update_state(event=Event.E10_RECEIVED_METADATA_PDU, pdu=self.metadata)
+        for i in range(0, len(self.pdus)):
+            self.receiver.update_state(event=Event.E11_RECEIVED_FILEDATA_PDU, pdu=self.pdus[i])
+        self.receiver.update_state(event=Event.E12_RECEIVED_EOF_NO_ERROR_PDU, pdu=self.eof)
+
+        for i in range(0, 5):
+            gevent.sleep(1)
+
+        # Assert nak list is 0 because we received everything
+        self.assertEqual(len(self.receiver.nak_list), 0, 'No naks to be processed because all data is received.')
+        self.assertEqual(filecmp.cmp(self.full_source_path, self.full_dest_path, shallow=True), True, 'Source and destination files are equal.')
+
+    def test_receiver2_has_naks(self):
+        """Ensure that receiver nak list is empty when all file data is received and that the source and destination files are equal"""
+
+        my_nak_list = []
+        self.receiver.update_state(event=Event.E10_RECEIVED_METADATA_PDU, pdu=self.metadata)
+        for i in range(0, len(self.pdus)):
+            # Only send every other file
+            if i % 2 == 0:
+                self.receiver.update_state(event=Event.E11_RECEIVED_FILEDATA_PDU, pdu=self.pdus[i])
+            else:
+                my_nak_list.append((self.pdus[i].segment_offset, self.pdus[i].segment_offset + len(self.pdus[i].data)))
+        self.receiver.update_state(event=Event.E12_RECEIVED_EOF_NO_ERROR_PDU, pdu=self.eof)
+
+        for i in range(0, 5):
+            gevent.sleep(1)
+
+        # Assert nak list is 0 because we received everything
+        my_nak_list = sorted(my_nak_list, key=lambda x: x[0])
+        self.assertItemsEqual(my_nak_list, self.receiver.nak_list, 'Receiver NAK list and recorded missed PDUs match');

--- a/ait/dsn/cfdp/test/sender_nak_test.py
+++ b/ait/dsn/cfdp/test/sender_nak_test.py
@@ -1,0 +1,207 @@
+# Advanced Multi-Mission Operations System (AMMOS) Instrument Toolkit (AIT)
+# Bespoke Link to Instruments and Small Satellites (BLISS)
+#
+# Copyright 2018, by the California Institute of Technology. ALL RIGHTS
+# RESERVED. United States Government Sponsorship acknowledged. Any
+# commercial use must be negotiated with the Office of Technology Transfer
+# at the California Institute of Technology.
+#
+# This software may be subject to U.S. export control laws. By accepting
+# this software, the user agrees to comply with all applicable U.S. export
+# laws and regulations. User has the responsibility to obtain export licenses,
+# or other export authority as may be required before exporting such
+# information to foreign countries or providing access to foreign persons.
+
+import os
+import glob
+import shutil
+import unittest
+import copy
+from functools import partial
+import filecmp
+import mock
+from random import randint
+
+import gevent
+import traceback
+
+import ait.core
+import ait.core.log
+from ait.dsn.cfdp import CFDP
+from ait.dsn.cfdp.events import Event
+from ait.dsn.cfdp.machines import Sender2
+from ait.dsn.cfdp.pdu import FileData, Metadata, EOF, NAK
+from ait.dsn.cfdp.cfdp import read_incoming_pdu, write_outgoing_pdu
+from ait.dsn.cfdp.request import create_request_from_type
+from ait.dsn.cfdp.util import string_length_in_bytes, calc_file_size, check_file_structure, calc_checksum
+from ait.dsn.cfdp.pdu import Header, Metadata, EOF, FileData, ACK, NAK, Finished
+from ait.dsn.cfdp.primitives import ConditionCode, TransactionStatus, DirectiveCode, FinishedPduFileStatus, TransmissionMode, RequestType
+
+
+TEST_DIRECTORY = os.path.join(os.path.dirname(__file__), '.pdusink')
+def setUpModule():
+    if not os.path.exists(TEST_DIRECTORY):
+        os.makedirs(TEST_DIRECTORY)
+
+def tearDownModule():
+    if os.path.exists(TEST_DIRECTORY):
+        shutil.rmtree(TEST_DIRECTORY)
+
+
+class Sender2NakTest(unittest.TestCase):
+
+    full_source_path = None
+
+    def setUp(self):
+        self.cfdp = CFDP(1)
+        self.source_path = 'medium.txt'
+        self.destination_path = 'test/path/med.txt'
+        self.full_source_path = os.path.join(self.cfdp._data_paths['outgoing'], self.source_path)
+        self.full_dest_path = os.path.join(self.cfdp._data_paths['incoming'], self.destination_path)
+
+        self.sender = Sender2(self.cfdp, 1)
+        # give sender a received list to keep track of PDUs to nak in the patched send method
+        self.sender._received_list = []
+        self.cfdp._machines[1] = self.sender
+
+        # CREATE PDUS
+        self.pdus = []
+
+        # MAKE HEADER
+        self.header = Header()
+        self.header.direction = Header.TOWARDS_RECEIVER
+        self.header.entity_ids_length = 8
+        self.header.transaction_id_length = 8
+        self.header.source_entity_id = 1
+        self.header.transaction_id = 1
+        self.header.destination_entity_id = 2
+        self.header.transmission_mode = TransmissionMode.ACK
+
+        # MAKE METADATA
+        data_field_length_octets = 6
+        # Each of these is +1 for 8 bit length field
+        data_field_length_octets += (string_length_in_bytes(self.source_path) + 1)
+        data_field_length_octets += (string_length_in_bytes(self.destination_path) + 1)
+        self.header.pdu_data_field_length = data_field_length_octets
+
+        file_size = calc_file_size(self.full_source_path)
+
+        # Copy header
+        header = copy.copy(self.header)
+        header.pdu_type = Header.FILE_DIRECTIVE_PDU
+        self.metadata = Metadata(
+            header=header,
+            source_path=self.source_path,
+            destination_path=self.destination_path,
+            file_size=file_size)
+
+        # MAKE FILE DATA PDUS
+        with open(self.full_source_path, 'rb') as file:
+            for chunk in iter(partial(file.read, 1024), ''):
+                offset = file.tell() - len(chunk)
+                header = copy.copy(self.header)
+                header.pdu_type = Header.FILE_DATA_PDU
+
+                # Calculate pdu data field length for header
+                data_field_length_octets = 4
+                # Get file data size
+                data_field_length_octets += len(chunk)
+                header.pdu_data_field_length = data_field_length_octets
+
+                fd = FileData(
+                    header=header,
+                    segment_offset=offset,
+                    data=chunk)
+                self.pdus.append(fd)
+
+        # MAKE EOF
+        header = copy.copy(self.header)
+        header.pdu_type = Header.FILE_DIRECTIVE_PDU
+        data_field_length_octets = 10
+        header.pdu_data_field_length = data_field_length_octets
+
+        self.eof = EOF(
+            header=header,
+            condition_code=ConditionCode.NO_ERROR,
+            file_checksum=calc_checksum(self.full_source_path),
+            file_size=self.metadata.file_size
+        )
+
+    def tearDown(self):
+        self.fixture = None
+        for f in glob.glob(os.path.join(TEST_DIRECTORY, '*')):
+            os.remove(f)
+
+        self.cfdp.disconnect()
+
+        # clear data from datasink
+        if os.path.exists(self.cfdp._data_paths['incoming']):
+            shutil.rmtree(self.cfdp._data_paths['incoming'])
+            os.makedirs(self.cfdp._data_paths['incoming'])
+
+        if os.path.exists(self.cfdp._data_paths['tempfiles']):
+            shutil.rmtree(self.cfdp._data_paths['tempfiles'])
+            os.makedirs(self.cfdp._data_paths['tempfiles'])
+
+        if os.path.exists(self.cfdp._data_paths['pdusink']):
+            shutil.rmtree(self.cfdp._data_paths['pdusink'])
+            os.makedirs(self.cfdp._data_paths['pdusink'])
+
+    def send(self, pdu):
+        """Mock CFDP.send() to catch the Sender's pdus"""
+        sender = self._machines[1]
+        print '\n***CAUGHT SEND OF PDU***\n', pdu
+        if type(pdu) == FileData:
+            # skip random file data
+            if randint(0, 9) % 2 == 0:
+                sender._received_list.append({'offset': pdu.segment_offset, 'length': len(pdu.data)})
+
+        elif type(pdu) == EOF:
+            # Received EOF, so evaluate the missed PDUs and create a NAK sequence
+            received_list = sorted(sender._received_list, key=lambda x: x.get('offset'))
+            nak_list = []
+            for index, item in enumerate(received_list):
+                if index == 0 and item.get('offset') != 0:
+                    # Check the first received and figure out if we are missing the first FileData PDU (if offset != 0)
+                    start = 0
+                    end = item.get('offset')
+                    nak_list.append((start, end))
+                elif index == len(received_list) - 1 and item.get('offset') + item.get(
+                        'length') + 1 < sender.metadata.file_size:
+                    # Check the last received and figure out if we are missing the last FileData PDU (if offset != file size)
+                    start = item.get('offset') + item.get('length')
+                    end = sender.metadata.file_size
+                    nak_list.append((start, end))
+                else:
+                    # Compare the item to the previous item to figure out if there is a gap between contiguous items
+                    prev_item = received_list[index - 1]
+                    if prev_item.get('offset') + prev_item.get('length') + 1 < item.get('offset'):
+                        start = prev_item.get('offset') + prev_item.get('length')
+                        end = item.get('offset')
+                        nak_list.append((start, end))
+
+            # create the NAK pdu
+            start_scope = 0
+            end_scope = sender.metadata.file_size
+            nak = NAK(header=sender.header, start_of_scope=start_scope, end_of_scope=end_scope,
+                      segment_requests=nak_list)
+            sender.kernel.send(nak)
+
+        elif type(pdu) == NAK:
+            # Catch the sending of the NAK and treat is as if receiving NAK from the receiver. Transmit the missing data
+            sender.update_state(Event.E15_RECEIVED_NAK_PDU, pdu=pdu)
+
+
+    @unittest.skip('TODO finish test implementation when ACK procedures are implemented')
+    @mock.patch.object(ait.dsn.cfdp.CFDP, 'send', send)
+    def test_sender2_resends_segment_requests(self):
+        """Ensure that sender nak list is empty when all file data is received and that the source and destination files are equal"""
+
+        request = create_request_from_type(RequestType.PUT_REQUEST,
+                                           destination_id=2,
+                                           source_path=self.source_path,
+                                           destination_path=self.destination_path,
+                                           transmission_mode=TransmissionMode.ACK)
+        self.sender.update_state(event=Event.E30_RECEIVED_PUT_REQUEST, request=request)
+
+        gevent.sleep(10)

--- a/ait/dsn/cfdp/util.py
+++ b/ait/dsn/cfdp/util.py
@@ -92,7 +92,7 @@ def checksum_of_word(word_list):
         word_list:
             list of integers with max length 4 (more will be ignored), each integer representing a byte
     """
-    if len(word_list) < 4:
+    while len(word_list) < 4:
         word_list.append(0)
     word = word_list[0] << 24
     word += word_list[1] << 16


### PR DESCRIPTION
Closes #47, closes #48 

Work towards epic #52

- Implementation of NAK procedures for Class 2 sender and receiver
- Unit tests for NAK functionality, although complete Sender test implementation depends on ACK procedure implementation