### PR TITLE
Issue #73 - CFDP send/receive over UDP socket connection

### DIFF
--- a/ait/dsn/bin/ait_cfdp_start_receiver
+++ b/ait/dsn/bin/ait_cfdp_start_receiver
@@ -25,7 +25,7 @@ if __name__ == '__main__':
 
     cfdp = ait.dsn.cfdp.CFDP(2)
     try:
-        cfdp.connect(('localhost', 8002), rcv_sock=('localhost', 8003))
+        cfdp.connect(('localhost', 8002), send_sock=('localhost', 8003))
         # Set the address of the counterpart
         # cfdp.mib.set_remote('1', 'ut_address', ('127.0.0.1', 8001))
         while True:

--- a/ait/dsn/bin/ait_cfdp_start_receiver
+++ b/ait/dsn/bin/ait_cfdp_start_receiver
@@ -25,7 +25,7 @@ if __name__ == '__main__':
 
     cfdp = ait.dsn.cfdp.CFDP(2)
     try:
-        cfdp.connect(('localhost', 8002), ('localhost', 8003))
+        cfdp.connect(('localhost', 8002), rcv_sock=('localhost', 8003))
         # Set the address of the counterpart
         # cfdp.mib.set_remote('1', 'ut_address', ('127.0.0.1', 8001))
         while True:

--- a/ait/dsn/bin/ait_cfdp_start_receiver
+++ b/ait/dsn/bin/ait_cfdp_start_receiver
@@ -25,7 +25,7 @@ if __name__ == '__main__':
 
     cfdp = ait.dsn.cfdp.CFDP(2)
     try:
-        cfdp.connect(('localhost', 8002), send_sock=('localhost', 8003))
+        cfdp.connect(('localhost', 8002), send_host=('localhost', 8003))
         # Set the address of the counterpart
         # cfdp.mib.set_remote('1', 'ut_address', ('127.0.0.1', 8001))
         while True:

--- a/ait/dsn/bin/ait_cfdp_start_receiver
+++ b/ait/dsn/bin/ait_cfdp_start_receiver
@@ -25,7 +25,7 @@ if __name__ == '__main__':
 
     cfdp = ait.dsn.cfdp.CFDP(2)
     try:
-        cfdp.connect(('localhost', 8002))
+        cfdp.connect(('localhost', 8002), ('localhost', 8003))
         # Set the address of the counterpart
         # cfdp.mib.set_remote('1', 'ut_address', ('127.0.0.1', 8001))
         while True:

--- a/ait/dsn/bin/ait_cfdp_start_receiver
+++ b/ait/dsn/bin/ait_cfdp_start_receiver
@@ -25,7 +25,7 @@ if __name__ == '__main__':
 
     cfdp = ait.dsn.cfdp.CFDP(2)
     try:
-        cfdp.connect(('127.0.0.1', 8002))
+        cfdp.connect(('localhost', 8002))
         # Set the address of the counterpart
         # cfdp.mib.set_remote('1', 'ut_address', ('127.0.0.1', 8001))
         while True:

--- a/ait/dsn/bin/ait_cfdp_start_sender.py
+++ b/ait/dsn/bin/ait_cfdp_start_sender.py
@@ -25,7 +25,7 @@ import ait.core.log
 if __name__ == '__main__':
     cfdp = ait.dsn.cfdp.CFDP(1)
     try:
-        cfdp.connect(('localhost', 8003), send_sock=('localhost', 8002))
+        cfdp.connect(('localhost', 8003), send_host=('localhost', 8002))
         # Set address of counterpart
         # cfdp.mib.set_remote('2', 'ut_address', ('127.0.0.1', 9002))
 

--- a/ait/dsn/bin/ait_cfdp_start_sender.py
+++ b/ait/dsn/bin/ait_cfdp_start_sender.py
@@ -25,7 +25,7 @@ import ait.core.log
 if __name__ == '__main__':
     cfdp = ait.dsn.cfdp.CFDP(1)
     try:
-        cfdp.connect(('127.0.0.1', 9001))
+        cfdp.connect(('localhost', 8003), ('localhost', 8002))
         # Set address of counterpart
         # cfdp.mib.set_remote('2', 'ut_address', ('127.0.0.1', 9002))
 

--- a/ait/dsn/bin/ait_cfdp_start_sender.py
+++ b/ait/dsn/bin/ait_cfdp_start_sender.py
@@ -25,7 +25,7 @@ import ait.core.log
 if __name__ == '__main__':
     cfdp = ait.dsn.cfdp.CFDP(1)
     try:
-        cfdp.connect(('localhost', 8003), rcv_sock=('localhost', 8002))
+        cfdp.connect(('localhost', 8003), send_sock=('localhost', 8002))
         # Set address of counterpart
         # cfdp.mib.set_remote('2', 'ut_address', ('127.0.0.1', 9002))
 

--- a/ait/dsn/bin/ait_cfdp_start_sender.py
+++ b/ait/dsn/bin/ait_cfdp_start_sender.py
@@ -25,7 +25,7 @@ import ait.core.log
 if __name__ == '__main__':
     cfdp = ait.dsn.cfdp.CFDP(1)
     try:
-        cfdp.connect(('localhost', 8003), ('localhost', 8002))
+        cfdp.connect(('localhost', 8003), rcv_sock=('localhost', 8002))
         # Set address of counterpart
         # cfdp.mib.set_remote('2', 'ut_address', ('127.0.0.1', 9002))
 

--- a/ait/dsn/bin/examples/tm_downlink_example.py
+++ b/ait/dsn/bin/examples/tm_downlink_example.py
@@ -50,8 +50,8 @@ from pyasn1.codec.der.decoder import decode
 
 from hexdump import hexdump
 
-from bliss.sle.pdu.raf import *
-from bliss.sle.pdu import raf
+from ait.dsn.sle.pdu.raf import *
+from ait.dsn.sle.pdu import raf
 
 TML_CONTEXT_MSG_FORMAT = '!IIbbbbIHH'
 TML_CONTEXT_MSG_TYPE = 0x02000000

--- a/ait/dsn/cfdp/cfdp.py
+++ b/ait/dsn/cfdp/cfdp.py
@@ -104,11 +104,14 @@ class CFDP(object):
 
     def disconnect(self):
         """Disconnect TC here"""
-        self._rcvr_socket.close()
-        self._sender_socket.close()
-        self._receiving_handler.kill()
-        self._sending_handler.kill()
-        self.mib.dump()
+        try:
+            self._rcvr_socket.close()
+            self._sender_socket.close()
+            self._receiving_handler.kill()
+            self._sending_handler.kill()
+            self.mib.dump()
+        except Exception:
+            pass
 
     def _increment_tx_counter(self):
         self.transaction_counter += 1

--- a/ait/dsn/cfdp/cfdp.py
+++ b/ait/dsn/cfdp/cfdp.py
@@ -82,9 +82,14 @@ class CFDP(object):
             if not os.path.exists(path):
                 os.makedirs(path)
 
-    def connect(self, send_sock, rcv_sock):
+    def connect(self, send_sock, rcv_sock=None):
         """Connect with UDP here"""
-        self.send_sock, self.rcv_sock = send_sock, rcv_sock
+        if rcv_sock:
+            self.send_sock, self.rcv_sock = send_sock, rcv_sock
+        else:
+            # send & receive over same socket
+            self.send_sock, self.rcv_sock = send_sock, send_sock
+
         self._rcvr_socket = gevent.socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
         self._sender_socket = gevent.socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
 

--- a/ait/dsn/cfdp/cfdp.py
+++ b/ait/dsn/cfdp/cfdp.py
@@ -112,11 +112,12 @@ class CFDP(object):
         try:
             self._rcvr_socket.close()
             self._sender_socket.close()
-            self._receiving_handler.kill()
-            self._sending_handler.kill()
-            self.mib.dump()
         except Exception:
             pass
+
+        self._receiving_handler.kill()
+        self._sending_handler.kill()
+        self.mib.dump()
 
     def _increment_tx_counter(self):
         self.transaction_counter += 1

--- a/ait/dsn/cfdp/cfdp.py
+++ b/ait/dsn/cfdp/cfdp.py
@@ -272,7 +272,6 @@ def read_pdus_from_filesys(instance):
         except Exception as e:
             ait.core.log.warn("EXCEPTION: " + e.message)
             ait.core.log.warn(traceback.format_exc())
-        gevent.sleep(0.2)
 
 
 def read_pdus_from_socket(instance):
@@ -296,7 +295,6 @@ def read_pdus_from_socket(instance):
         except Exception as e:
             ait.core.log.warn("EXCEPTION: " + e.message)
             ait.core.log.warn(traceback.format_exc())
-        gevent.sleep(0.2)
 
 
 def receiving_handler(instance):

--- a/ait/dsn/cfdp/cfdp.py
+++ b/ait/dsn/cfdp/cfdp.py
@@ -82,16 +82,18 @@ class CFDP(object):
             if not os.path.exists(path):
                 os.makedirs(path)
 
-    def connect(self, send_sock, rcv_sock=None):
-        """Connect with UDP here"""
-        if rcv_sock:
-            self.send_sock, self.rcv_sock = send_sock, rcv_sock
-        else:
-            # send & receive over same socket
-            self.send_sock, self.rcv_sock = send_sock, send_sock
+    def connect(self, rcv_sock, send_sock=None):
+        """Connect with UDP here - only connect to socket for receiving if send socket is
+        no specified. """
 
+        # setup receive socket
+        self.rcv_sock = rcv_sock
         self._rcvr_socket = gevent.socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
-        self._sender_socket = gevent.socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+
+        # setup send socket if specified
+        if send_sock:
+            self.send_sock = send_sock
+            self._sender_socket = gevent.socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
 
         # Bind to receiver socket (no bind to sender socket)
         connected = False
@@ -102,10 +104,10 @@ class CFDP(object):
                 connected = True
 
             except socket.error as e:
-                print(e)
+                ait.core.log.error('Error connecting to socket: {}'.format(e))
                 gevent.sleep(1)
 
-        ait.core.log.info('Connected to socket')
+        ait.core.log.info('Connected to receiving socket')
 
     def disconnect(self):
         """Disconnect TC here"""

--- a/ait/dsn/cfdp/mib.py
+++ b/ait/dsn/cfdp/mib.py
@@ -146,7 +146,7 @@ class MIB(object):
             yaml.dump(self._local, mib_file, default_flow_style=False)
 
     def load(self, path=None):
-        """Write MIB to yaml"""
+        """Read MIB from yaml"""
         if path is None:
             path = self._path
 

--- a/ait/dsn/cfdp/pdu/__init__.py
+++ b/ait/dsn/cfdp/pdu/__init__.py
@@ -17,4 +17,4 @@ from md import Metadata
 from eof import EOF
 from filedata import FileData
 from header import Header
-from util import make_pdu_from_bytes
+from util import make_pdu_from_bytes, split_multiple_pdu_byte_array

--- a/ait/dsn/cfdp/pdu/header.py
+++ b/ait/dsn/cfdp/pdu/header.py
@@ -81,6 +81,7 @@ class Header(object):
         self.destination_entity_id = kwargs.get('destination_entity_id', None)
         self.entity_ids_length = kwargs.get('entity_ids_length', None)
         self.transaction_id_length = kwargs.get('transaction_id_length', None)
+        self.header_length = kwargs.get('header_length', None)
 
     def __copy__(self):
         newone = type(self)()
@@ -292,10 +293,11 @@ class Header(object):
             direction=direction,
             transmission_mode=transmission_mode,
             crc_flag=crc_flag,
+            header_length=expected_length,
             pdu_data_field_length=pdu_data_length,
             source_entity_id=source_entity_id,
             transaction_id=transaction_id,
             destination_entity_id=destination_entity_id,
-            entity_ids_length = entity_ids_length,
-            transaction_id_length = transaction_id_length
+            entity_ids_length=entity_ids_length,
+            transaction_id_length=transaction_id_length
         )


### PR DESCRIPTION
- CFDP implementation can now send/receive over UDP ports - a single CFDP entity can send & receive over the same or different ports. 
- By default an entity only connects to a receiving port if a sending port is not specified.
- The example scripts now send/receive over different corresponding ports for testing on the same machine (i.e. the sending entity sends over the same port that the receiving entity receives on, and vice versa).
- Option to send/receive over file system can be passed into CFDP initializer as kwarg
- Some formatting and typos fixed.