### PR TITLE
Issue 76 - add option to pull hostname / port from config

### DIFF
--- a/ait/dsn/sle/common.py
+++ b/ait/dsn/sle/common.py
@@ -99,8 +99,10 @@ class SLE(object):
         ''''''
         self._downlink_frame_type = ait.config.get('dsn.sle.downlink_frame_type',
                                       kwargs.get('downlink_frame_type', 'TMTransFrame'))
-        self._hostname = kwargs.get('hostname', None)
-        self._port = kwargs.get('port', None)
+        self._hostname = ait.config.get('dsn.sle.hostname',
+                                        kwargs.get('hostname', None))
+        self._port = ait.config.get('dsn.sle.port',
+                                        kwargs.get('port', None))
         self._heartbeat = ait.config.get('dsn.sle.heartbeat',
                                            kwargs.get('heartbeat', 25))
         self._deadfactor = ait.config.get('dsn.sle.deadfactor',

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -30,17 +30,20 @@ default:
 
     dsn:
         sle:
-            initiator_id: uname
+            initiator_id: LSE
+            # password only matters if we're doing auth and can stay as 'pw'
             password: pw
-            responder_id: uname
+            responder_id: SSE
+            # peer password only matters if we're doing auth and can stay as 'pw'
             peer_password: pw
             version: 5
             downlink_frame_type: TMTransFrame
-            heartbeat: heartbeat
-            deadfactor: deadfactor
-            buffer_size: buffer_size
-            responder_port: responder_port
-            auth_level: auth_level
+            heartbeat: 25
+            deadfactor: 5
+            buffer_size: 256000
+            responder_port: 'default'
+            auth_level: 'none'
+
         cfdp:
             mib:
                 path: ./mib

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -43,6 +43,8 @@ default:
             buffer_size: 256000
             responder_port: 'default'
             auth_level: 'none'
+            hostname: None
+            port: None
 
         cfdp:
             mib:


### PR DESCRIPTION
Bring back `self._hostname = kwargs.get('hostname', None)` and `self._port = kwargs.get('port', None)` to pre `28ae827` state. Add hostname and port to SLE config parameter.