### PR TITLE
Issue #60: Implement AOS Transfer Frames per Spec

### DIFF
--- a/ait/dsn/sle/frames.py
+++ b/ait/dsn/sle/frames.py
@@ -1,7 +1,6 @@
 # Advanced Multi-Mission Operations System (AMMOS) Instrument Toolkit (AIT)
-# Bespoke Link to Instruments and Small Satellites (BLISS)
 #
-# Copyright 2017, by the California Institute of Technology. ALL RIGHTS
+# Copyright 2020, by the California Institute of Technology. ALL RIGHTS
 # RESERVED. United States Government Sponsorship acknowledged. Any
 # commercial use must be negotiated with the Office of Technology Transfer
 # at the California Institute of Technology.
@@ -11,44 +10,109 @@
 # laws and regulations. User has the responsibility to obtain export licenses,
 # or other export authority as may be required before exporting such
 # information to foreign countries or providing access to foreign persons.
+from typing import Any
 
-from .util import *
+from ait.dsn.sle.util import *
+from enum import Enum
+import ait
 
-class TMTransFrame(dict):
+class BaseTransferFrame(dict):
+    ''' Transfer Frame interface "base" class
+
+    The BaseTransformFrame class provides Transfer Frame interface-agnostic methods
+    and attributes for interfacing with Frames.
+    '''
+
     def __init__(self, data=None):
-        super(TMTransFrame, self).__init__()
+        super(BaseTransferFrame, self).__init__()
 
         self._data = []
         self.is_idle = False
         self.has_no_pkts = False
-        if data:
-            self.decode(data)
+
+    @property
+    def virtual_channel(self):
+        ''' Returns Virtual Channel ID (integer) '''
+        if 'virtual_channel_id' in self:
+            return self['virtual_channel_id']
+        else:
+            return None
+
+    @property
+    def master_channel_id(self):
+        ''' Returns Master Channel ID (integer) '''
+        if 'master_channel_id' in self:
+            return self['master_channel_id']
+        else:
+            return None
+
+    def contains_data(self):
+        ''' Returns True if frame contains data, False otherwise
+
+        Returns:
+            Boolean value indicating if frame contains data
+        '''
+        if self.is_idle or self.has_no_pkts:
+            return False
+        if len(self._data) == 0:
+            return False
+        return True
+
+    @property
+    def data_field(self):
+        ''' Returns the data portion of the transfer frame.
+
+        :return: The frame data portion, including potential inner-dataframe headers
+        '''
+        if self.contains_data():
+            return self._data[0]
+        else:
+            return None
+
+    @property
+    def is_idle_frame(self):
+        ''' Returns True if this frame is an Idle frame, as indicated by
+         the special Idle virtual channel ID, False otherwise.
+         (Note: This is different from an M_PDU Idle data-field section)
+
+        Returns:
+             Boolean value indicating if this is an IDLE frame.
+        '''
+        return self.is_idle
+
+
+class TMTransFrame(BaseTransferFrame):
+    def __init__(self, data=None):
+        super(TMTransFrame, self).__init__()
 
     def decode(self, data):
         ''' Decode data as a TM Transfer Frame '''
-        self['version'] = hexint(data[0]) & 0xC0
-        self['spacecraft_id'] = hexint(data[0:2]) & 0x3FF0
-        self['virtual_channel_id'] = hexint(data[1]) & 0x0E
-        self['ocf_flag'] = hexint(data[1]) & 0x01
-        self['master_chan_frame_count'] = data[2]
-        self['virtual_chan_frame_count'] = data[3]
-        self['sec_header_flag'] = hexint(data[4:6]) & 0x8000
-        self['sync_flag'] = hexint(data[4:6]) & 0x4000
-        self['pkt_order_flag'] = hexint(data[4:6]) & 0x2000
-        self['seg_len_id'] = hexint(data[4:6]) & 0x1800
+        self['master_channel_id'] = (hexint(data[0:2]) & 0xFFF0) >> 4  # 12 bits
+        self['version'] = (hexint(data[0]) & 0xC0) >> 6  # 2 bits
+        self['spacecraft_id'] = (hexint(data[0:2]) & 0x3FF0) >> 4  # 10 bits
+        self['virtual_channel_id'] = (hexint(data[1]) & 0x0E) >> 1  # 1 bit
+        self['ocf_flag'] = hexint(data[1]) & 0x01 # 1 bit
+        self['master_chan_frame_count'] = hexint(data[2])  # 8 bits
+        self['virtual_chan_frame_count'] = hexint(data[3]) # 8 bits
+
+        self['sec_header_flag'] = (hexint(data[4:6]) & 0x8000) >> 15 #1 bit
+        self['sync_flag'] = (hexint(data[4:6]) & 0x4000) >> 14  # 1 bit
+        self['pkt_order_flag'] = (hexint(data[4:6]) & 0x2000) >> 13  # 1 bit
+        self['seg_len_id'] = (hexint(data[4:6]) & 0x1800) >> 11   # 2 bits
         self['first_hdr_ptr'] = hexint(data[4:6]) & 0x07FF
 
-        if self['first_hdr_ptr'] == b'11111111110':
+
+        if str(bin(self['first_hdr_ptr'])) == '0b11111111110':
             self.is_idle = True
             return
 
-        if self['first_hdr_ptr'] == b'11111111111':
+        if str(bin(self['first_hdr_ptr'])) == '0b11111111111':
             self.has_no_pkts = True
             return
 
         # Process the secondary header. This hasn't been tested ...
         if self['sec_header_flag']:
-            self['sec_hdr_ver'] = hexint(data[6]) & 0xC0
+            self['sec_hdr_ver'] = (hexint(data[6]) & 0xC0) >> 6
             sec_hdr_len = hexint(data[6]) & 0x3F
             sec_hdr_data = data[7:7+sec_hdr_len]
             pkt_data = data[8 + sec_hdr_len:]
@@ -79,37 +143,445 @@ class TMTransFrame(dict):
     def encode(self):
         pass
 
-class AOSTransFrame(dict):
-    def __init__(self, data=None):
+
+class AOSDataFieldType(Enum):
+    '''
+    Enumeration for AOS Data Field types
+    '''
+    M_PDU   = "M_PDU"    # Multiplexing Protocol Data Unit
+    B_PDU   = "B_PDU"    # Bitstream Protocol Data Unit
+    VCA_SDU = "VCA_SDU"  # Virtual Channel Access Service Data Unit
+    IDLE    = "IDLE"     # Idle data
+
+
+class AOSConfig(object):
+    '''
+    AOS frame configuration class.
+
+    This configuration contains information regarding the inclusion
+    of optional AOS frame fields and a dictionary of virtual channel
+    values to AOS data frame types.
+    '''
+
+    def __init__(self, *args, **kwargs):
+
+        # By default the primary header is length 6
+        self.primary_header_min_len = 6
+
+        # Default index for the data field
+        self.data_field_startIndex = self.primary_header_min_len
+        self.data_field_endIndex   = None  # end of data array
+
+        # -----
+
+        # Default lengths of optional fields
+        self.frame_header_error_control_len = 0
+        self.transfer_frame_insert_zone_len = 0
+        self.operational_control_field_len  = 0
+        self.frame_error_control_field_len  = 0
+
+        # Start and end indices for optional fields
+        self.frame_header_error_control_startIndex = None
+        self.frame_header_error_control_endIndex   = None
+        self.transfer_frame_insert_zone_startIndex = None
+        self.transfer_frame_insert_zone_endIndex   = None
+        self.operational_control_field_startIndex  = None
+        self.operational_control_field_endIndex    = None
+        self.frame_error_control_field_startIndex  = None
+        self.frame_error_control_field_endIndex    = None
+
+        # -----
+
+        # AIT config section prefix
+        cfg_pfx = 'dsn.sle.aos.'
+
+        # Is frame header error control included? (2-octets)
+        prop_name = 'frame_header_error_control_included'
+        self.frame_header_error_control_included = \
+            kwargs.get(prop_name,
+            ait.config.get(cfg_pfx + prop_name, False))
+
+
+
+        if self.frame_header_error_control_included:
+            self.frame_header_error_control_len = 2
+            self.frame_header_error_control_startIndex = self.primary_header_min_len
+            self.frame_header_error_control_endIndex   = self.primary_header_min_len + \
+                                                       self.frame_header_error_control_len
+
+        # Is transfer frame insert zone included? If so, get its non-zero len, else 0
+        prop_name = 'transfer_frame_insert_zone_len'
+        self.transfer_frame_insert_zone_len = \
+            kwargs.get(prop_name,
+                       ait.config.get(cfg_pfx + prop_name,
+                                      0))
+
+        if self.transfer_frame_insert_zone_len > 0:
+            self.transfer_frame_insert_zone_startIndex = self.primary_header_min_len + \
+                                                         self.frame_header_error_control_len
+            self.transfer_frame_insert_zone_endIndex = self.transfer_frame_insert_zone_startIndex + \
+                                                       self.transfer_frame_insert_zone_len
+
+        # Is operation control field  included?
+        prop_name = 'operational_control_field_included'
+        self.operational_control_field_included = \
+            kwargs.get(prop_name,
+                       ait.config.get(cfg_pfx + prop_name,
+                                      False))
+
+        # Is frame error control field  included?
+        prop_name = 'frame_error_control_field_included'
+        self.frame_error_control_field_included = \
+            kwargs.get(prop_name,
+                       ait.config.get(cfg_pfx + prop_name,
+                                      False))
+
+        # Update lengths/indices based on settings
+
+        # operation control field length is 4 bytes (if included)
+        if self.operational_control_field_included:
+            self.operational_control_field_len = 4
+
+        # frame error control field is 2 bytes (if included)
+        if self.frame_error_control_field_included:
+            self.frame_error_control_field_len = 2
+
+        # calculate suffix fields indices (using offsets from the end of packet)
+        if self.operational_control_field_included and self.frame_error_control_field_included:
+            self.operational_control_field_startIndex = -6
+            self.operational_control_field_endIndex   = -2
+            self.frame_error_control_field_startIndex = -2
+            self.frame_error_control_field_endIndex   = None
+        elif self.operational_control_field_included:
+            self.operational_control_field_startIndex = -4
+            self.operational_control_field_endIndex = None
+        elif self.frame_error_control_field_included:
+            self.frame_error_control_field_startIndex = -2
+            self.frame_error_control_field_endIndex = None
+
+        # Calculate the indices of the data field
+        self.data_field_startIndex = self.primary_header_min_len + \
+                                    self.frame_header_error_control_len + \
+                                    self.transfer_frame_insert_zone_len
+        self.data_field_endIndex = -1 * (self.operational_control_field_len +
+                                     self.frame_error_control_field_len)
+        # Special case where there is no trailer sections, so force 0
+        # to be None so indices work correctly
+        if self.data_field_endIndex == 0:
+            self.data_field_endIndex = None
+
+        ## --------
+
+        # Collect virtual channel information, primarily the virtual channel
+        # id and to what datafield type it maps
+
+        self.vc_to_datafield_map = {}
+
+        # Maps property names to associated enum values
+        field_type_name_to_enums = {
+            "m_pdu"   : AOSDataFieldType.M_PDU,
+            "b_pdu"   : AOSDataFieldType.B_PDU,
+            "vca_sdu" : AOSDataFieldType.VCA_SDU,
+            "idle"    : AOSDataFieldType.IDLE
+        }
+
+
+        # Load the virtual channel map, mapping VC Ids to type.
+        # First check the kwargs, then ait config, then default
+        vc_map = kwargs.get('virtual_channels', None)
+        if not vc_map:
+            vc_aitcfg = ait.config.get('dsn.sle.aos.virtual_channels')
+            ## AitConfig instance is returned for underlying YAML
+            # dict types, so we need to extract the actual dict field
+            # from it (named _config). Might be nice to have a property
+            # method return this at some point?
+            if vc_aitcfg:
+                vc_map = vc_aitcfg._config
+            else:
+                vc_map = {}  # empty dict is the default
+
+        # iterate over VC config entries and create dict
+        # from VC id to DataField enum type
+        for vc_number in vc_map:
+            vc_field_str = vc_map[vc_number].lower()
+            if vc_field_str in field_type_name_to_enums:
+                vc_field_type = field_type_name_to_enums[vc_field_str]
+                self.vc_to_datafield_map[vc_number] = vc_field_type
+            else:
+                err = (
+                    'Virtual channel '+str(vc_number)+' is mapped to unrecognized type: '+vc_field_str+''
+                    'Skipping this configuration entry...'
+                )
+                ait.core.log.info(err)
+
+        # ---------------------------------------------
+
+    def get_data_field_type(self, vc_number):
+        ''' Returns the data field type associated with a virtual
+            channel id.  If the virtual channel id is undeclared,
+            then None is returned.
+        :param vc_number: THe virtual channel id number (int)
+        :return: AOSDataFieldType enum value associated with virtual channel id
+        '''
+        if vc_number in self.vc_to_datafield_map:
+            return self.vc_to_datafield_map[vc_number]
+        return None
+
+    def get_virtual_channel_count(self):
+        '''
+        Returns the size of the virtual channel data field type map
+        :return: size of virtual-channel data-field-type map
+        '''
+        return len(self.vc_to_datafield_map)
+
+    @property
+    def transfer_frame_insert_zone_included(self):
+        '''
+        Returns true if Transfer Frame Insert Zone field is defined in AOS Frame, false otherwise
+        :return: Flag indicating Transfer Frame Insert Zone field existence
+        '''
+        return self.transfer_frame_insert_zone_len > 0
+
+    def get_frame_header_error_control_indices(self):
+        '''
+        Returns the slice-indices for the Frame header control field if defined,
+        otherwise None is returned
+        :return: Frame header error control field indices or None
+        '''
+        if self.frame_header_error_control_included:
+            return self.frame_header_error_control_startIndex, \
+                   self.frame_header_error_control_endIndex
+        else:
+            return None, None
+
+    def get_transfer_frame_insert_zone_indices(self):
+        '''
+        Returns the slice-indices for the transfer frame insert zone if defined,
+        otherwise None is returned
+        :return: Transfer frame insert zone indices or None
+        '''
+        if self.transfer_frame_insert_zone_included:
+            return self.transfer_frame_insert_zone_startIndex, \
+                   self.transfer_frame_insert_zone_endIndex
+        else:
+            return None, None
+
+    def get_operational_control_field_indices(self):
+        '''
+        Returns the slice-indices for the operational control field if defined,
+        otherwise None is returned
+        :return: Operation control field indices or None
+        '''
+        if self.operational_control_field_included:
+            return self.transfer_frame_insert_zone_startIndex, \
+                   self.transfer_frame_insert_zone_endIndex
+        else:
+            return None, None
+
+    def get_frame_error_control_field_indices(self):
+        '''
+        Returns the slice-indices for the frame error control field if defined,
+        otherwise None is returned
+        :return: Frame error control field indices or None
+        '''
+        if self.frame_error_control_field_included:
+            return self.frame_error_control_field_startIndex, \
+                   self.frame_error_control_field_endIndex
+        else:
+            return None, None
+
+    def get_data_field_indices(self):
+        '''
+        Returns the slice-indices for the data field in AOS frame
+        :return: Data field indices
+        '''
+        return self.data_field_startIndex, self.data_field_endIndex
+
+
+class AOSTransFrame(BaseTransferFrame):
+    '''
+    Implementation of the AOS transfer frame.
+
+    The AOSTransFrame class decodes data packets to extract information from header,
+    data-field, and trailer.  An instance of AOSConfig guides the process by indicating
+    which optional fields are included, as well as determining the type of the datafield
+    via the virtual channel id.
+    '''
+
+    # Class level config for default
+    defaultConfig = AOSConfig()
+
+    def __init__(self, data=None, config=None):
         super(AOSTransFrame, self).__init__()
 
-        self._data = []
-        self.is_idle = False
-        self.has_no_pkts = False
+        # Use passed-in config or default
+        if config is None:
+            self.aosConfig = AOSTransFrame.defaultConfig
+        else:
+            self.aosConfig = config
+
         if data:
             self.decode(data)
 
+
     def decode(self, data):
         ''' Decode data as a AOS Transfer Frame '''
-        self['version'] = hexint(data[0]) & 0xC0 #bits 0:1
-        self['spacecraft_id'] = hexint(data[0:2]) & 0x3FC0 #bits 2:9
+        self['master_channel_id'] = (hexint(data[0:2]) & 0xFFC0) >> 6  #10 bits
+        self['version'] = (hexint(data[0]) & 0xC0) >> 6 #bits 0:1
+        self['spacecraft_id'] = (hexint(data[0:2]) & 0x3FC0) >> 6 #bits 2:9
         self['virtual_channel_id'] = hexint(data[1]) & 0x3F #bits 10:15
-        self['virtual_chan_frame_count'] = data[2:5]
-        self['signaling_field'] = data[5] #according to the AOS documentation, this is unused
-        self['first_hdr_ptr'] = data[6:8] & 0x03FF #this comes from the m_pdu_header
+        self['virtual_channel_frame_count'] = data[2:5]
 
-        if self['virtual_channel_id'] == b'111111': #according to AOS documentation, 0x3F indicates idle AOS transfer frames
+        signaling_field = hexint(data[5])
+        self['replay_flag'] = (signaling_field & 0x80)  >> 7 # 1 bit
+        self['virtual_channel_frame_count_cycle_use_flag'] = (signaling_field & 0x40) >> 6  # 1 bit
+        self['signal_field_reserved'] = (signaling_field & 0x30) >> 4 # 2 bits, should be '00'
+        self['virtual_channel_frame_count_cycle'] = (signaling_field & 0x0F)  # 4 bits
+
+        # check if frame header error control section is included
+        if self.aosConfig.frame_header_error_control_included:
+            beg_idx, end_idx = self.aosConfig.get_frame_header_error_control_indices()
+            self['frame_header_error_control'] = data[beg_idx:end_idx]
+        else:
+            self['frame_header_error_control'] = None
+
+        # check if transfer frame insert zone section is included
+        if self.aosConfig.transfer_frame_insert_zone_included:
+            beg_idx, end_idx = self.aosConfig.get_transfer_frame_insert_zone_indices()
+            self['transfer_frame_insert_zone'] = data[beg_idx:end_idx]
+        else:
+            self['transfer_frame_insert_zone'] = None
+
+        # Check for special IDLE virtual channel ID (0x3F indicates idle AOS transfer frames)
+        if str(bin(self['virtual_channel_id'])) == '0b111111':
             self.is_idle = True
-            return
-
-        #offset to first byte of ccsds header (2047 means no data)
-        if self['first_hdr_ptr'] == b'11111111111':
             self.has_no_pkts = True
+            self['aos_data_field_type'] = None
             return
 
-        pkt_data = data[6:(len(data)-2)]
+        # Per AOS documentation, if only one Virtual Channel is used, then
+        # the bits are set to 'all-zeros'
+        # Question: is all-zeros but more than one VCs an issue?
+        if str(bin(self['virtual_channel_id'])) == '0b000000':
+            if self.aosConfig.get_virtual_channel_count() == 1:
+                pass
+            else:
+                pass  # For now just proceed
 
-        self._data.append(pkt_data)
+        ## Get the general data field body
+        beg_idx, end_idx = self.aosConfig.get_data_field_indices()
+
+        data_field =  data[beg_idx:end_idx]
+        #self._data = data_field
+        self._data.append(data_field)
+
+        # Decode the contents of the data field
+        self.decode_data_field(data_field)
+
+        # check if operational control field is included
+        if self.aosConfig.operational_control_field_included:
+            beg_idx, end_idx = self.aosConfig.get_operational_control_field_indices()
+            self['operational_control_field'] = data[beg_idx:end_idx]
+        else:
+            self['operational_control_field'] = None
+
+        # check if frame error control field is included
+        if self.aosConfig.frame_error_control_field_included:
+            beg_idx, end_idx = self.aosConfig.get_frame_error_control_field_indices()
+            self['frame_error_control_field'] = data[beg_idx:end_idx]
+        else:
+            self['frame_error_control_field'] = None
+
+
+    def decode_data_field(self, datafield):
+        ''' Decode the data-field section of the data, using the virtual
+        channel id which indicates that data field type
+
+        :param datafield: Data-field section of the AOS frame
+        '''
+        vc_key = self.virtual_channel
+        vc_df_type = self.aosConfig.get_data_field_type(vc_key)
+
+        if vc_df_type is None:
+            err = (
+                'AOSTransFrame received data with undeclared virtual channel ('+str(vc_key)+'). '
+                'Skipping further processing of this AOS transfer frame data field...'
+            )
+            ait.core.log.info(err)
+            pass
+        elif vc_df_type == AOSDataFieldType.M_PDU:
+            self.decode_dataField_MPDU(datafield)
+        elif vc_df_type == AOSDataFieldType.B_PDU:
+            self.decode_dataField_BPDU(datafield)
+        elif vc_df_type == AOSDataFieldType.VCA_SDU:
+            self.decode_dataField_VCASDU(datafield)
+        elif vc_df_type == AOSDataFieldType.IDLE:
+            self.decode_dataField_Idle(datafield)
+        else:
+            err = (
+                    'AOSTransFrame received data with unknown virtual channel type (' + str(vc_df_type) + '). '
+                    'Skipping further processing of this AOS transfer frame data field...'
+            )
+            ait.core.log.info(err)
+            pass
+
+    def decode_dataField_MPDU(self, datafield):
+        ''' Decodes the M_PDU datafield
+
+        :param datafield: AOS datafield to be decoded
+        '''
+        self['aos_data_field_type'] = AOSDataFieldType.M_PDU
+
+        # M_PDU header: 5 bits reserved, 11 first header pointer: 07FF
+        # Note: If all ones, then datafield does not contain a start of a packet
+        self['mpdu_first_hdr_ptr'] = hexint(datafield[0:2]) & 0x07FF
+
+        # Remaining: M_PDU packet zone
+        # In general, this may contain a series of CCSDS packets,
+        # but for now, someone downstream will handle processing it
+        self['mpdu_packet_zone'] = datafield[2:]
+
+
+        # AOS Spec 4.1.4.2.3.5 If the M_PDU Packet Zone contains only Idle Data,
+        # the First Header Pointer
+        # shall be set to 'all ones minus one'.
+        self['mpdu_is_idle_data'] = (str(bin(self['mpdu_first_hdr_ptr'])) == '0b11111111110')
+
+        self['mpdu_contains_idle_data'] = (str(bin(self['mpdu_first_hdr_ptr'])) == '0b11111111110')
+
+    def decode_dataField_BPDU(self, datafield):
+        ''' Decodes the B_PDU datafield
+
+        :param datafield: AOS datafield to be decoded
+         '''
+        self['aos_data_field_type'] = AOSDataFieldType.B_PDU
+
+        # B_PDU header: 2 bits reserved, 14 bitstream data pointer: 3FFF
+        self['bpdu_bitstream_data_ptr'] = hexint(datafield[0:2]) & 0x3FFF
+
+        # Remaining: B_PDU bitstream data zone
+        self['bpdu_data_zone'] = datafield[2:]
+
+        # AOS Spec 4.1.4.3.3.4 If there are no valid user data in the Bitstream
+        # Data Zone (i.e., the B_PDU contains only idle data), the Bitstream
+        # Data Pointer shall be set to the value 'all ones minus one'.
+        self['bpdu_contains_idle_data'] = (self['bpdu_bitstream_data_ptr'] == b'11111111111110')
+
+    def decode_dataField_VCASDU(self, datafield):
+        ''' Decodes the VCA_SDU datafield
+
+        :param datafield: AOS datafield to be decoded
+        '''
+        self['aos_data_field_type'] = AOSDataFieldType.VCA_SDU
+        self['vcasdu_data_zone'] = datafield[None:None]
+
+    def decode_dataField_Idle(self, datafield):
+        ''' Decodes the IDLE datafield
+
+        :param datafield: AOS datafield to be decoded
+        '''
+        self['aos_data_field_type'] = AOSDataFieldType.IDLE
+        self['idle_data_zone'] = datafield[None:None]
 
     def encode(self):
         pass

--- a/ait/dsn/sle/test/__init__.py
+++ b/ait/dsn/sle/test/__init__.py
@@ -1,7 +1,7 @@
 # Advanced Multi-Mission Operations System (AMMOS) Instrument Toolkit (AIT)
 # Bespoke Link to Instruments and Small Satellites (BLISS)
 #
-# Copyright 2017, by the California Institute of Technology. ALL RIGHTS
+# Copyright 2018, by the California Institute of Technology. ALL RIGHTS
 # RESERVED. United States Government Sponsorship acknowledged. Any
 # commercial use must be negotiated with the Office of Technology Transfer
 # at the California Institute of Technology.
@@ -11,13 +11,3 @@
 # laws and regulations. User has the responsibility to obtain export licenses,
 # or other export authority as may be required before exporting such
 # information to foreign countries or providing access to foreign persons.
-
-import binascii
-
-def hexint(b):
-    if not b:
-        return int()
-    elif isinstance(b, int):
-        return b
-    else:
-        return int(binascii.hexlify(b), 16)

--- a/ait/dsn/sle/test/frames_test.py
+++ b/ait/dsn/sle/test/frames_test.py
@@ -1,0 +1,244 @@
+# Advanced Multi-Mission Operations System (AMMOS) Instrument Toolkit (AIT)
+# Bespoke Link to Instruments and Small Satellites (BLISS)
+#
+# Copyright 2018, by the California Institute of Technology. ALL RIGHTS
+# RESERVED. United States Government Sponsorship acknowledged. Any
+# commercial use must be negotiated with the Office of Technology Transfer
+# at the California Institute of Technology.
+#
+# This software may be subject to U.S. export control laws. By accepting
+# this software, the user agrees to comply with all applicable U.S. export
+# laws and regulations. User has the responsibility to obtain export licenses,
+# or other export authority as may be required before exporting such
+# information to foreign countries or providing access to foreign persons.
+
+import os
+import unittest
+import mock
+
+import ait.core
+from ait.dsn.sle.frames import AOSTransFrame, AOSConfig, AOSDataFieldType
+
+# Supress logging because noisy
+patcher = mock.patch('ait.core.log.info')
+patcher.start()
+
+
+class AosTest(unittest.TestCase):
+
+    def setUp(self):
+        # Create a config instance (otherwise we would need to update the cfg yaml)
+
+        # The virtual channel map which maps virtual channel ids (integer) to
+        # a string indicating the type of the AOS data
+        # fields (b_pdu,m_pdu.vca_sdu,idle)
+        self.virt_chan_map = {1: "b_pdu",
+                              2: "m_pdu",
+                              3: "vca_sdu",
+                              4: "idle"}
+
+        # The shared AOS config, indicating which optional fields exists and the
+        # Virtual channel map
+        self.aos_cfg = AOSConfig(virtual_channels=self.virt_chan_map,
+                                 frame_header_error_control_included=True,
+                                 operational_control_field_included=True,
+                                 frame_error_control_field_included=True)
+
+    def tearDown(self):
+        pass
+
+    def test_decode_aos_mpdu(self):
+
+        # ver, spccrft,vrtchn  ...  vc frm cnt       ...    signalin     ..frmHdrErrCtrl..
+        # 01,110011 10,000010 00000000 00000000 00000001,  1,0,01,0101   00000000 00000001
+        frame_data_hdr = "7382000001950001"
+
+        # M_PDU header: 5 bits reserved, 11 first header pointer: 07FF
+        # 00000,000 00001111   00000001 000100011 01000101  01100111
+        # Remaining: M_PDU packet zone
+        frame_data_body = "000F01234567"
+        frame_data_body = "07FE01234567"  # 07FE Indicates idle mpdu data
+
+        # frame data trailer: four and two bytes
+        frame_data_trlr = "000003FF0880"
+
+        data_hex_str = frame_data_hdr + frame_data_body + frame_data_trlr
+
+        frame_data = bytes.fromhex(data_hex_str)
+
+        aos_frame = AOSTransFrame(config=self.aos_cfg, data=frame_data)
+
+        # Test super-class methods / property-access
+        frame_vc = aos_frame.virtual_channel
+        mstr_chan_id = aos_frame.master_channel_id
+        has_data = aos_frame.contains_data()
+        data_field = aos_frame.data_field
+
+        # Test direct access of signal field parts
+        df_type = aos_frame['aos_data_field_type']
+        replay_flag = aos_frame['replay_flag']
+        vc_fc_c_uf = aos_frame['virtual_channel_frame_count_cycle_use_flag']
+        vc_fc_c = aos_frame['virtual_channel_frame_count_cycle']
+
+
+        self.assertEqual(mstr_chan_id, 462)
+        self.assertEqual(frame_vc, 2)
+        self.assertEqual(df_type, AOSDataFieldType.M_PDU)
+        self.assertNotEqual(df_type, AOSDataFieldType.B_PDU)
+
+        self.assertEqual(replay_flag, 1)
+        self.assertEqual(vc_fc_c_uf,  0)
+        self.assertEqual(vc_fc_c, 5)
+
+        self.assertTrue(has_data)
+
+
+        self.assertEqual(data_field.hex(), '07fe01234567')
+
+        mpdu_data = aos_frame['mpdu_packet_zone']
+        self.assertEqual(mpdu_data.hex(), '01234567')
+
+        mpdu_data_idle = aos_frame['mpdu_is_idle_data']
+        self.assertTrue(mpdu_data_idle)
+
+
+
+
+    def test_decode_aos_bpdu(self):
+
+        # ver, spccrft,vrtchn  ...  vc frm cnt       ...    signalin     ..frmHdrErrCtrl..
+        # 01,110011 10,000001 00000000 00000000 00000001,  0,0,01,0001   00000000 00000001
+        frame_data_hdr = "7381000001110001"
+
+        # B_PDU header: 2 bits reserved, 14 bitstream data pointer: 010F
+        # 00,000001 00001111, then random octets
+
+        # Remaining: B_PDU packet zone
+        frame_data_body = "010F01234567"
+
+        # frame data trailer: four and two bytes
+        frame_data_trlr = "000003FF0880"
+
+        data_hex_str = frame_data_hdr + frame_data_body + frame_data_trlr
+        frame_data = bytes.fromhex(data_hex_str)
+        aos_frame = AOSTransFrame(config=self.aos_cfg, data=frame_data)
+
+        frame_vc = aos_frame.virtual_channel
+        mstr_chan_id = aos_frame.master_channel_id
+        df_type = aos_frame['aos_data_field_type']
+
+        has_data = aos_frame.contains_data()
+
+        self.assertEqual(mstr_chan_id, 462)
+        self.assertEqual(frame_vc, 1)
+        self.assertEqual(df_type, AOSDataFieldType.B_PDU)
+        self.assertTrue(has_data)
+
+        bpdu_ptr = aos_frame['bpdu_bitstream_data_ptr']
+        bpdu_idle = aos_frame['bpdu_contains_idle_data']  ##True when (self['bpdu_bitstream_data_ptr'] == b'11111111111110')
+        bpdu_data = aos_frame['bpdu_data_zone']
+
+        self.assertFalse(bpdu_idle)
+
+
+
+
+    def test_decode_aos_pkt_idle(self):
+
+        # Higher level idle packet (When aosfrm['virtual_channel_id'] == b'111111')
+
+        # ver, spccrft,vrtchn  ...  vc frm cnt       ...    signalin     ..frmHdrErrCtrl..
+        # 01,110011 10,111111 00000000 00000000 00000001,  0,0,01,0001   00000000 00000001
+        frame_data_hdr = "73BF000001110001"
+
+        # No data field
+        frame_data_body = ""
+
+        # frame data trailer: four and two bytes
+        frame_data_trlr = "000003FF0880"
+
+        data_hex_str = frame_data_hdr + frame_data_body + frame_data_trlr
+        frame_data = bytes.fromhex(data_hex_str)
+        aos_frame = AOSTransFrame(config=self.aos_cfg, data=frame_data)
+
+        frame_vc = aos_frame.virtual_channel
+        mstr_chan_id = aos_frame.master_channel_id
+        df_type = aos_frame['aos_data_field_type']
+        is_idle = aos_frame.is_idle_frame
+        self.assertTrue(is_idle)
+        self.assertIsNone(df_type)
+
+
+
+
+    def test_decode_aos_df_idle(self):
+
+        # ver, spccrft,vrtchn  ...  vc frm cnt       ...    signalin     ..frmHdrErrCtrl..
+        # 01,110011 10,000100 00000000 00000000 00000001,  0,0,01,0001   00000000 00000001
+        frame_data_hdr = "7384000001110001"
+
+        # M_PDU header: 5 bits reserved, 11 first header pointer: 07FF
+        # 00000,000 00001111   00000001 000100011 01000101  01100111
+
+        # Remaining: M_PDU packet zone
+        frame_data_body = "000F01234567"
+
+        # frame data trailer: four and two bytes
+        frame_data_trlr = "000003FF0880"
+
+        data_hex_str = frame_data_hdr + frame_data_body + frame_data_trlr
+        frame_data = bytes.fromhex(data_hex_str)
+        aos_frame = AOSTransFrame(config=self.aos_cfg, data=frame_data)
+
+        frame_vc = aos_frame.virtual_channel
+        mstr_chan_id = aos_frame.master_channel_id
+        df_type = aos_frame['aos_data_field_type']
+
+        self.assertEqual(df_type, AOSDataFieldType.IDLE)
+        has_data = aos_frame.contains_data()
+        self.assertTrue(has_data)
+
+    def test_decode_aos_vcasdu(self):
+
+        # ver, spccrft,vrtchn  ...  vc frm cnt       ...    signalin     ..frmHdrErrCtrl..
+        # 01,110011 10,000011 00000000 00000000 00000001,  0,0,01,0001   00000000 00000001
+        frame_data_hdr = "7383000001110001"
+
+        # VCASDU, just data with no header/trailer
+        frame_data_body = "01234567"
+
+        # frame data trailer: four and two bytes
+        frame_data_trlr = "000003FF0880"
+
+        data_hex_str = frame_data_hdr + frame_data_body + frame_data_trlr
+
+        frame_data = bytes.fromhex(data_hex_str)
+
+        aos_frame = AOSTransFrame(config=self.aos_cfg, data=frame_data)
+        df_type = aos_frame['aos_data_field_type']
+
+        # Test data field type
+        self.assertEqual(df_type, AOSDataFieldType.VCA_SDU)
+
+        # test that all datafield is VCASDU data field
+        vcasdu_data = aos_frame['vcasdu_data_zone']
+        self.assertEqual(vcasdu_data.hex(), '01234567')
+
+    def test_default_config(self):
+        l_aos_cfg = AOSConfig()
+
+        self.assertFalse(l_aos_cfg.operational_control_field_included)
+        self.assertFalse(l_aos_cfg.frame_error_control_field_included)
+        self.assertFalse(l_aos_cfg.frame_header_error_control_included)
+        self.assertEqual(l_aos_cfg.operational_control_field_len, 0)
+
+        # default config sould have virtual channel 1 assigned a type
+        self.assertIsNotNone(l_aos_cfg.get_data_field_type(1))
+
+        # But these virtual channel ids should all be undefined
+        self.assertIsNone(l_aos_cfg.get_data_field_type(100))
+        self.assertIsNone(l_aos_cfg.get_data_field_type(-1))
+
+
+    def test_reject_encode(self):
+        pass

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -67,7 +67,18 @@ default:
                 port: None
                 version: 4
                 auth_level: 'none'
+            aos:
+                frame_header_error_control_included: false
+                transfer_frame_insert_zone_len: 0
+                operational_control_field_included: false
+                frame_error_control_field_included: false
+                virtual_channels:
+                    1: "b_pdu"
+                    2: "m_pdu"
+                    3: "vca_sdu"
+                    4: "idle"
 
+                    
         cfdp:
             mib:
                 path: ./mib


### PR DESCRIPTION
This PR includes AOS Transfer frame implementation based on the 'AOS Space Data Link Protocol' specification. 
AOS Transfer frames spec includes a set of optional fields to be decided by the mission, so this information is captured in a new class, AosConfig, which can be populated from a kwargs map or AIT config file, within the 'dsn.sle.aos.' section.
Some refactoring was performed such that TmFrame and AosFrame classes have a common base-class, BaseTransferFrame. 
TmFrame decoding was updated to include bit shifting as necessary for sub-octet fields.
A new unit test file, test/test_frames.py, exercises much of the AOS Transfer frame decoding.

Resolves #60 