### PR TITLE
DSN Example script cleanup

### DIFF
--- a/ait/dsn/bin/examples/cltu_api_test.py
+++ b/ait/dsn/bin/examples/cltu_api_test.py
@@ -14,9 +14,17 @@
 # or other export authority as may be required before exporting such
 # information to foreign countries or providing access to foreign persons.
 
-# Usage:
-#   Move this script to ait/config/script so that it can be accessed within ait-gui
-#   Run this script within the AIT Script Control dashboard
+# SSPSim Config:
+# 1. Open "MISSION MANAGERS" >  "Test" > "RAF ONLC1"
+# 2. Ensure that the Production Id is set to "TestBaseband1"
+# 4. Open "PRODUCTION" > "TestBaseband1"
+# 5. Ensure that Spacecraft Id is set to 250
+# 6. Activate the TC data flow by clicking the green arrow
+#       labelled "TC"
+# 7. Activate the TM simulation data creation by clicking the
+#       green arrow labelled "SIM".
+# 8. Activate the Mission Manager interface by clicking the
+#       green arrow labelled "SVC"
 
 import datetime as dt
 import time

--- a/ait/dsn/bin/examples/raf_api_test.py
+++ b/ait/dsn/bin/examples/raf_api_test.py
@@ -15,23 +15,19 @@
 # information to foreign countries or providing access to foreign persons.
 
 # Usage:
-#   python rcf_api_test.py
+#   python raf_api_test.py
 #
 # SSPSim Config:
-# 1. Open "MISSION MANAGERS" >  "Test" > "RCFv2 ONLC2"
-# 2. Ensure that the Production Id is set to "TestBaseband2"
+# 1. Open "MISSION MANAGERS" >  "Test" > "RAF ONLC1"
+# 2. Ensure that the Production Id is set to "TestBaseband1"
 # 3. Ensure that GVCID is set to (250, 0, *)
-# 4. Open "PRODUCTION" > "TestBaseband2"
+# 4. Open "PRODUCTION" > "TestBaseband1"
 # 5. Ensure that Spacecraft Id is set to 250
-# 6. Ensure that VCID is checked and set to 6
-# 7. Ensure the Source field is set to DUMMY. **NOTE**, the
-#       generated data will not contain the VCID you set unless
-#       you use the DUMMY data source.
-# 8. Activate the TM data flow by clicking the green arrow
+# 6. Activate the TM data flow by clicking the green arrow
 #       labelled "TM"
-# 9. Activate the TM simulation data creation by clicking the
+# 7. Activate the TM simulation data creation by clicking the
 #       green arrow labelled "SIM".
-# 10. Activate the Mission Manager interface by clicking the
+# 8. Activate the Mission Manager interface by clicking the
 #       green arrow labelled "SVC"
 #
 # Run the script per the usage instructions above. You should see
@@ -45,38 +41,32 @@
 # repeatedly strips 6 bytes off the packet data to process as a CCSDS header.
 # As such, (Telem Frame Length - 6 bytes for the TM Header) % 6 should be 0.
 # If it's not you'll likely encounter problems.
-#
-# You can confirm that virtual channels are working by using the commented
-# out start call in the script instead. Try changing the virtual_channel
-# parameter to a number that doesn't match the VCID you set in step 6 above.
-# You should see the connection go through but no data will be received.
 
 import datetime as dt
 import time
 
 import ait.dsn.sle
 
-# runtime parameters will override config file defaults
-rcf_mngr = ait.dsn.sle.RCF(
+raf_mngr = ait.dsn.sle.RAF(
     hostnames=['atb-ocio-sspsim.jpl.nasa.gov'],
     port=5100,
-    inst_id='sagr=LSE-SSC.spack=Test.rsl-fg=1.rcf=onlc2',
+    inst_id='sagr=LSE-SSC.spack=Test.rsl-fg=1.raf=onlc1',
     spacecraft_id=250,
     trans_frame_ver_num=0,
     version=4,
     auth_level="none"
 )
 
-rcf_mngr.connect()
+raf_mngr.connect()
 time.sleep(2)
 
-rcf_mngr.bind()
+raf_mngr.bind()
 time.sleep(2)
 
 start = dt.datetime(2017, 1, 1)
-end = dt.datetime(2019, 1, 1)
-# rcf_mngr.start(start, end, 250, 0, virtual_channel=6)
-rcf_mngr.start(start, end, 250, 0, master_channel=True)
+end = dt.datetime(2021, 1, 1)
+# raf_mngr.start(start, end)
+raf_mngr.start(None, None)
 
 try:
     while True:
@@ -85,11 +75,11 @@ except:
     pass
 finally:
 
-    rcf_mngr.stop()
+    raf_mngr.stop()
     time.sleep(2)
 
-    rcf_mngr.unbind()
+    raf_mngr.unbind()
     time.sleep(2)
 
-    rcf_mngr.disconnect()
+    raf_mngr.disconnect()
     time.sleep(2)


### PR DESCRIPTION
Cleanup some of the example scripts to address minor issues with the 3.x
cutover and make documentation clearer.