### PR TITLE
Issue #110 - RAF/RCF emits entire frame contents to a frame-specific …

### DIFF
--- a/ait/dsn/sle/__init__.py
+++ b/ait/dsn/sle/__init__.py
@@ -12,6 +12,11 @@
 # or other export authority as may be required before exporting such
 # information to foreign countries or providing access to foreign persons.
 
+import sys
+
 from .raf import RAF
 from .rcf import RCF
 from .cltu import CLTU
+
+# Default port to which Frames will be emitted by SLE RAF/RCF ('FRAM')
+sys.modules['ait'].DEFAULT_FRAME_PORT = 3726


### PR DESCRIPTION
…port

Changes
- Added new default frame port with value of 3726 ('F-R-A-M' on phone keypad)
- Updated constructors to init frame_output_port field
- Updated data handlers to drop idle frames, and emit everything else to the frame port.


Fixes #110 