### PR TITLE
Issue #118 - Convert string to byte string on common.py

### DIFF
--- a/ait/dsn/bin/examples/cltu_api_test.py
+++ b/ait/dsn/bin/examples/cltu_api_test.py
@@ -14,25 +14,38 @@
 # or other export authority as may be required before exporting such
 # information to foreign countries or providing access to foreign persons.
 
+# Usage:
+#   python cltu_api_test.py
+#
 # SSPSim Config:
-# 1. Open "MISSION MANAGERS" >  "Test" > "RAF ONLC1"
-# 2. Ensure that the Production Id is set to "TestBaseband1"
-# 4. Open "PRODUCTION" > "TestBaseband1"
-# 5. Ensure that Spacecraft Id is set to 250
-# 6. Activate the TC data flow by clicking the green arrow
-#       labelled "TC"
-# 7. Activate the TM simulation data creation by clicking the
-#       green arrow labelled "SIM".
-# 8. Activate the Mission Manager interface by clicking the
+# 1. Open "MISSION MANAGERS" >  "Test" > "FCLTU - PLOP1"
+# 2. Open "PRODUCTION" > "TestBaseband1" (Check "Production Id" on "FCLTU-POP1" for Baseband #)
+# 3. Activate the production interface by clicking the
+#       green arrow labelled "TC"
+# 4. Activate the Mission Manager interface by clicking the
 #       green arrow labelled "SVC"
+# 5. Set dsn.sle.version in config.yaml to the desire version to test (4 or 5). See note below for expected behavior.
+#
+# Run the script per the usage instructions above. You should see
+# logging informing you of the various steps in the script. If all
+# runs as expected you should see confirmations back from the sim
+# indicating which cltu id was last processed. These will also be
+# mirrored in the sim GUI where you'll be informed when a particular
+# cltu id has been successfully radiated.
+
 
 import datetime as dt
 import time
 
 import ait.dsn.sle
 
-# CLTU pulls parameters from config file by default
-cltu_mngr = ait.dsn.sle.CLTU()
+cltu_mngr = ait.dsn.sle.CLTU(
+    hostnames=['atb-ocio-sspsim.jpl.nasa.gov'],
+    port=5100,
+    inst_id='sagr=LSE-SSC.spack=Test.fsl-fg=1.cltu=cltu1',
+    auth_level="none",
+    version=5,
+)
 
 cltu_mngr.connect()
 time.sleep(2)

--- a/ait/dsn/sle/cltu.py
+++ b/ait/dsn/sle/cltu.py
@@ -509,7 +509,7 @@ class CLTU(common.SLE):
                 lp = pdu['cltuLastProcessed'].getComponent()
                 t = 'unknown'
                 if 'known' in lp['radiationStartTime']:
-                    t = binascii.hexlify(str(lp['radiationStartTime'].getComponent().getComponent()))
+                    t = binascii.hexlify((lp['radiationStartTime'].getComponent().getComponent()).asOctets())
 
                 msg += 'Last Processed: id: {} | rad start: {} | status: {}\n'.format(
                     lp['cltuIdentification'],
@@ -522,7 +522,7 @@ class CLTU(common.SLE):
                 msg += 'Last Ok: No CLTU Ok\n'
             else:
                 lok = pdu['cltuLastOk'].getComponent()
-                t = binascii.hexlify(str(lok['radiationStopTime'].getComponent()))
+                t = binascii.hexlify((lok['radiationStopTime'].getComponent()).asOctets())
 
                 msg += 'Last Ok: id: {} | end: {}\n'.format(lok['cltuIdentification'], t)
 

--- a/ait/dsn/sle/common.py
+++ b/ait/dsn/sle/common.py
@@ -432,7 +432,7 @@ class SLE(object):
 def conn_handler(handler):
     ''' Handler for processing data received from the DSN into PDUs'''
     hb_time = int(time.time())
-    msg = ''
+    msg = b''
 
     while True:
         gevent.sleep(0)
@@ -451,7 +451,7 @@ def conn_handler(handler):
             hdr, rem = msg[:8], msg[8:]
 
             # PDU Received
-            if binascii.hexlify(hdr[:4]) == '01000000':
+            if binascii.hexlify(hdr[:4]) == b'01000000':
                 # Get length of body and check if the entirety of the
                 # body has been received. If we can, process the message(s)
                 body_len = util.hexint(hdr[4:])
@@ -462,7 +462,7 @@ def conn_handler(handler):
                     handler._data_queue.put(hdr + body)
                     msg = msg[len(hdr) + len(body):]
             # Heartbeat Received
-            elif binascii.hexlify(hdr[:8]) == '0300000000000000':
+            elif binascii.hexlify(hdr[:8]) == b'0300000000000000':
                 msg = rem
             else:
                 err = (


### PR DESCRIPTION
This PR is to fix bugs found during RAF, RCF, and CLTU API testings (#117 #118 #128 #129 )

RAF/RCF API Test: 
The following strings need to be converted to byte-strings
https://github.com/NASA-AMMOS/AIT-DSN/blob/4780d6d5c54a2b7b6ee71285bd08d15e2c937129/ait/dsn/sle/common.py#L435

https://github.com/NASA-AMMOS/AIT-DSN/blob/4780d6d5c54a2b7b6ee71285bd08d15e2c937129/ait/dsn/sle/common.py#L454

https://github.com/NASA-AMMOS/AIT-DSN/blob/4780d6d5c54a2b7b6ee71285bd08d15e2c937129/ait/dsn/sle/common.py#L465

CLTU API Test
The following need to be converted to byte object:
https://github.com/NASA-AMMOS/AIT-DSN/blob/c4d74a1b2cdeb2590fc3ce66b1dc7db2c00835c9/ait/dsn/sle/cltu.py#L512

https://github.com/NASA-AMMOS/AIT-DSN/blob/c4d74a1b2cdeb2590fc3ce66b1dc7db2c00835c9/ait/dsn/sle/cltu.py#L525
