### PR TITLE
Fix Issue #124– Check if SLE instance is connected to the DSN before sending heartbeats

### DIFF
--- a/ait/dsn/sle/common.py
+++ b/ait/dsn/sle/common.py
@@ -136,9 +136,6 @@ class SLE(object):
             'random_number': None
         }
 
-        self._conn_monitor = gevent.spawn(conn_handler, self)
-        self._data_processor = gevent.spawn(data_processor, self)
-
     @property
     def invoke_id(self):
         ''''''
@@ -289,6 +286,9 @@ class SLE(object):
                 break
             except socket.error as e:
                 ait.core.log.info('Failed to connect to DSN at {}. Trying next hostname.'.format(hostname))
+
+        self._conn_monitor = gevent.spawn(conn_handler, self)
+        self._data_processor = gevent.spawn(data_processor, self)
 
         if not connected:
             ait.core.log.error('Connection failure with DSN. Aborting ...')


### PR DESCRIPTION
Fix Issue #124 by spawning the connection handler gevent process after the DSN socket is created and the object is connected to the DSN. Prior to this bug fix, users receive an error stating that "`class does not have attribute '_socket'`" when an SLE object is instantiated but not immediately connected to the DSN (i.e. `.connect()` is not run immediately after instantiating the object). This is due to the connection handler function, which sends heartbeats to the DSN, being spawned as a gevent process in `__init__`.