### PR TITLE
Issue 140: Engineering release of AIT encryption support

### DIFF
--- a/ait/dsn/bin/ait_encrypt.py
+++ b/ait/dsn/bin/ait_encrypt.py
@@ -1,0 +1,244 @@
+#!/usr/bin/env python
+
+import argparse
+from collections import OrderedDict
+
+from pathlib import Path
+import sys
+import ait.core
+from ait.dsn.encrypt.encrypter import EncryptMode, EncryptResult, EncrypterFactory, BaseEncrypter
+import traceback
+
+'''
+
+usage: ait_encrypt.py [-h] --mode {encrypt,decrypt} --type TYPE --input INPUT 
+                      [--output OUTPUT] [--verbose]
+
+Performs encryption or decryption on bytes from a file.
+
+optional arguments:
+  -h, --help            show this help message and exit
+  --mode {encrypt,decrypt}
+                        Mode: 'encrypt', 'decrypt' (default: encrypt)
+  --type TYPE           Type of encrypter to use: 'null', 'kmc'; or full class name
+                        (default: null)
+  --input INPUT         Input filename, required. (default: None)
+  --output OUTPUT       Output filename, optional. (default: None)
+  --verbose             Print debug messages. (default: False)
+  
+Examples:
+
+  $ ait_encrypt --mode encrypt --type null --input input.bin  --output output.bin
+  $ ait_encrypt --mode decrypt --type null --input output.bin --output restored.bin
+  
+'''
+
+this = sys.modules[__name__]
+
+# Dict from short-name to full classname for known Encrypters
+this.encrypter_class_map = {'null'  : 'ait.dsn.encrypt.encrypter.NullEncrypter',
+                       'kmc'   : 'ait.dsn.encrypt.kmc_encrypter.KmcSdlsEncrypter'}
+
+this.debug_enabled = False
+
+
+def main():
+
+    descr = "Performs encryption or decryption on bytes from a file."
+
+    parser = argparse.ArgumentParser(
+
+        description=descr,
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter
+    )
+
+    encrypt_mode_list = list(map(lambda x: x.name.lower(), EncryptMode))
+    encrypt_mode_list_str = str(encrypt_mode_list)[1:-1]
+
+    encrypt_type_list = list(this.encrypter_class_map.keys())
+    encrypt_type_list_str = str(encrypt_type_list)[1:-1]
+
+    arg_defns = OrderedDict({
+        '--mode': {
+            'type': str,
+            'default': EncryptMode.ENCRYPT.name.lower(),
+            'choices' : encrypt_mode_list,
+            'help': f"Mode: {encrypt_mode_list_str}",
+            'required': True
+        },
+        '--type': {
+            'type': str,
+            'default': 'null',
+            'help': f"Type of encrypter to use: {encrypt_type_list_str}; or full class name",
+            'required': True
+        },
+        '--input': {
+            'type': str,
+            'default': None,
+            'help': 'Input filename, required.',
+            'required': True
+        },
+        '--output': {
+            'type': str,
+            'default': None,
+            'help': 'Output filename, optional.'
+        },
+        '--verbose': {
+            'action': 'store_true',
+            'default': False,
+            'help': 'Print debug messages.'
+        },
+
+    })
+
+
+    ## Push argument defs to the parser
+    for name, params in arg_defns.items():
+        parser.add_argument(name, **params)
+
+    ## Get arg results of the parser
+    args = parser.parse_args()
+
+    type = args.type
+    mode = args.mode
+    in_filename = args.input
+    out_filename  = args.output
+    this.debug_enabled = args.verbose
+
+
+
+    if mode not in encrypt_mode_list:
+        ait.core.log.error(f"Unrecognized encryption mode option: {mode}")
+        ait.core.log.error(f"Legal values are: {encrypt_mode_list_str}")
+        sys.exit()
+
+    encrypt_mode = EncryptMode[mode.upper()]
+
+    in_filepath = Path(in_filename)
+    if not in_filepath.is_file():
+        ait.core.log.error(f"File '{in_filename}' does not exist")
+        sys.exit()
+
+    in_file = open(in_filename, "rb")
+    in_data = in_file.read()
+    in_file.close()
+
+    if this.debug_enabled:
+        ait.core.log.info(f"Input:\n{in_data.hex()}")
+
+    # Convert bytes to bytearray
+    in_byte_arr  = bytearray(in_data)
+
+    # Captures the processing output (as bytearray)
+    out_byte_arr = None
+    try:
+        out_byte_arr = process_data(in_byte_arr, encrypt_mode, type)
+    except Exception as ex:
+        ait.core.log.error(f"Error occurred during processing: {ex}")
+        traceback.print_exc()
+        sys.exit()
+
+    if out_byte_arr is not None:
+        out_data = bytes(out_byte_arr)
+
+
+        if out_filename:
+            # Write to file
+            if this.debug_enabled:
+                ait.core.log.info(f"Saving result to {out_filename}")
+            out_file = open(out_filename, "wb")
+            out_file.write(out_data)
+            out_file.close()
+        else:
+            # Write to screen
+            out_data_str = out_data.hex()
+            if this.debug_enabled:
+                ait.core.log.info(f"Result:\n{out_data_str}")
+            else:
+                print(f"{out_data_str}")
+    else:
+        ait.core.log.error(f"No output from processing.")
+        sys.exit()
+
+def get_encrypter(type=None):
+    '''
+    Returns a newly instantiated, configured and connected Encrypter instance
+    If type is shortname per encrypter class dict, then associated class is used.
+    If type contains a period, it is assumed to be the full encrypter class name
+    If type is None, then a default encrypter will be returned
+    :param type: Short name based on supported map, or full encrypter class name, or None
+    :return: New Encrypter instance
+    '''
+    encrypter_clazz = None
+    encrypter_inst = None
+
+    # If type contains a period, assume its the full classname
+    if type is not None:
+        if '.' in type:
+            encrypter_clazz = type
+        elif type in this.encrypter_class_map.keys():
+            encrypter_clazz = this.encrypter_class_map.get(type)
+
+    encrypter_inst = EncrypterFactory().get(encrypter_clazz)
+
+    if encrypter_inst:
+        encrypter_inst.configure(debug_enabled=this.debug_enabled)
+        encrypter_inst.connect()
+
+    return encrypter_inst
+
+def process_data(in_data, mode, encr_type=None):
+    '''
+    Process the input data, based on the mode and encrypter type
+    :param mode: EncryptMode enum
+    :param in_data: Input data
+    :param encr_type: Type of the Encrypter to use
+    :return: Processed (encrypted or decrypted) output as bytearray, no None
+    '''
+
+    out_data = None
+
+    encr = get_encrypter(encr_type)
+
+    if not encr:
+        ait.core.log.error(f"Unable to create encrypter with id '{encr_type}'")
+        return None
+    elif not encr.is_configured():
+        ait.core.log.error(f"Encrypter was created but is not configured.")
+        return None
+    elif not encr.is_connected():
+        ait.core.log.error(f"Encrypter was created but is not connected.")
+        return None
+
+    if this.debug_enabled:
+        encr_cgf = encr.show_config()
+        ait.core.log.info(f"Encrypter information: {encr_cgf}")
+
+    if mode == EncryptMode.ENCRYPT:
+        if this.debug_enabled:
+            ait.core.log.info(f"Performing encryption...")
+        ait_result = encr.encrypt(in_data)
+    elif mode == EncryptMode.DECRYPT:
+        if this.debug_enabled:
+            ait.core.log.info(f"Performing decryption...")
+        ait_result = encr.decrypt(in_data)
+    else:
+        ait.core.log.error(f"Unrecognized mode: {mode}")
+        return None
+
+    if ait_result is not None:
+        if ait_result.has_result:
+            out_data = ait_result.result
+        elif ait_result.errors is not None:
+            for e in ait_result.errors:
+                ait.core.log.error(f"Error occurred during processing: {e}")
+
+    encr.close()
+
+    return out_data
+
+
+
+
+if __name__ == '__main__':
+  main()

--- a/ait/dsn/encrypt/encrypter.py
+++ b/ait/dsn/encrypt/encrypter.py
@@ -1,0 +1,301 @@
+
+from abc import ABCMeta, abstractmethod
+import importlib
+import copy
+from enum import Enum
+
+import ait
+import ait.core.cfg
+import ait.core.log
+
+"""
+AIT Encryption Classes and Functions
+
+The ait.dsn.encrypt.encrypter module provides the API for encryption.
+"""
+
+'''
+AIT Yaml Config Layout:
+
+default:
+    dsn:
+        encryption:
+            vcid_filter: [list of vcids for which encryption applies]  #None means all VCIDs included, empty list means No VCID's allowed
+            client:
+                name: ait.dsn.encrypt.module.class
+                config:
+                    <client-specific-config, parsed by impl>
+
+'''
+
+class EncryptMode(Enum):
+    '''
+    Enumeration for Encryption modes / directions
+    '''
+    ENCRYPT = 0
+    DECRYPT = 1
+
+class EncryptResult():
+    '''AIT Encryption result wrapper.
+
+    :class:`EncryptResult` is a minimal wrapper around encryption/decryption results /
+    errors. All AIT encryption APIs that execute a encrypt and decrypt will return their results
+    wrapped in an :class:`EncryptResult` object.
+
+    :class:`EncryptResult` tracks four main attributes. Generally, an unused attribute
+    will be None.
+
+    **mode**
+        Enumeration of EncryptMode.  Value is either ENCRYPT or DECRYPT
+
+    **input**
+        The input bytearray.
+
+    **result**
+        The result of the encryption/decryption request, as bytearray.
+
+    **errors**
+        An iterator of errors encountered during transformation execution.
+
+    '''
+
+    def __init__(self, mode=EncryptMode.ENCRYPT, input=None, result=None, errors=None):
+        self._mode = mode
+        self._input = input
+        self._result = result
+        self._errors = errors
+
+    @property
+    def mode(self):
+        return self._mode
+
+    @property
+    def input(self):
+        return self._input
+
+    @property
+    def errors(self):
+        return self._errors
+
+    @property
+    def result(self):
+        return self._result
+
+    @property
+    def has_result(self):
+        return self._result is not None
+
+    @property
+    def has_errors(self):
+        return self._errors is not None and len(self._errors) > 0
+
+    def __repr__(self):
+        return (
+            f"EncryptResult("
+            f"mode: {self._mode.name.lower()}, "
+            f"has_input: {self._input is not None}, "
+            f"has_result: {self._result is not None}, "
+            f"has_errors: {self.has_errors})"
+        )
+
+
+
+
+
+class BaseEncrypter(object):
+    ''' Generic enrypter abstraction
+
+    BaseEncrypter attempts to adequately abstract encryption operations into
+    a small set of common methods. Not all methods will be useful for every
+    encrypter type and additional methods may need to be added for future
+    encryption support.
+
+    Generally, the expected method functionality should be
+
+        configure
+            Configure the instance, loading all necessary settings and
+            preparing for connection
+
+        connect
+            Connect to instance of the encryption service.
+
+        encrypt
+            Encrypt a payload
+
+        decrypt
+            Decrypt a payload
+
+        show_config
+            Method that displays the service configuration, useful for development/debugging.
+
+        close
+            Close the connection to the encryption service and handle any cleanup
+
+        is_connected
+            Returns True if encrypter is connected, False otherwise
+
+        is_configured
+            Returns True if encrypter is configured, False otherwise
+    '''
+
+    # Allows this class to be meta (as an abstract base class)
+    __metaclass__ = ABCMeta
+
+    prop_vcid_filter = 'vcid_filter'
+    prop_debug_enabled = 'debug_enabled'
+
+    cfg_prefix = "dsn.encryption."
+    cfg_client_name = cfg_prefix + "client.name"
+    cfg_client_name = cfg_prefix + "client.name"
+    cfg_client_config = cfg_prefix+"client.config"
+
+    def __init__(self):
+        self._vcids_filter = None
+        self._debug_enabled = False
+
+        self._configured = False
+
+
+    def configure(self, **kwargs):
+        '''Setup the configuration for this instance.'''
+
+        # Check if debug flag is included and set
+        self._debug_enabled = kwargs.get(BaseEncrypter.prop_debug_enabled,
+                                         ait.config.get(
+                                             f"{BaseEncrypter.cfg_prefix}.{BaseEncrypter.prop_debug_enabled}",
+                                             False))
+
+        # Pull in the list of VCID's for which encryption/decryption should be applied
+        lcl_vcid_list = kwargs.get(BaseEncrypter.prop_vcid_filter,
+                                   ait.config.get(
+                                       f"{BaseEncrypter.cfg_prefix}.{BaseEncrypter.prop_vcid_filter}", None))
+
+        # If not None but not a list, so a scalar, then convert to a list
+        if lcl_vcid_list is not None and not isinstance(lcl_vcid_list, list):
+            lcl_vcid_list = [lcl_vcid_list]
+
+        # None means no filtering applied, empty list means filter out all,
+        # otherwise filter contains list of VCID's for which encryption is allowed
+        self._vcids_filter = lcl_vcid_list
+
+        self._configured = True
+
+    @abstractmethod
+    def connect(self):
+        '''Connect to a backend's encryption instance.'''
+        pass
+
+    @abstractmethod
+    def encrypt(self, input_bytes):
+        pass
+
+    @abstractmethod
+    def decrypt(self, input_bytes):
+        pass
+
+    @abstractmethod
+    def show_config(self):
+        pass
+
+    def vcid_is_supported(self, vcid):
+        '''Returns True if vcid is registered to be encrypted or filter is None'''
+        return self._vcids_filter is None or vcid in self.supported_vcids
+
+    @abstractmethod
+    def close(self):
+        pass
+
+    @abstractmethod
+    def is_connected(self):
+        '''Returns True if encrypter is connected, False otherwise'''
+        pass
+
+    def is_configured(self):
+        '''Returns True if encrypter has been configured, False otherwise'''
+        return self._configured
+
+class NullEncrypter(BaseEncrypter):
+    ''' Null enrypter
+
+    NullEncrypter implements the GenericEncrypter interface while providing no actual
+    encryption or decryption.  Calls to either method will result in output
+    that is a copy of the input.
+    '''
+
+    def __init__(self):
+        '''No backend to load, so do not call the parent impl '''
+        self._is_connected = False
+
+    def configure(self,  **kwargs):
+        super().configure(**kwargs)
+
+    def connect(self):
+        '''No connection is needed for this instance.'''
+        self._is_connected = True
+
+    def encrypt(self, input_bytes):
+        if self._is_connected:
+            return EncryptResult(mode=EncryptMode.ENCRYPT, input=input_bytes, result=copy.copy(input_bytes))
+        else:
+            err_msg = "Client is not connected"
+            return EncryptResult(mode=EncryptMode.ENCRYPT, input=input_bytes, errors=[str(err_msg)])
+
+    def decrypt(self, input_bytes):
+        if self._is_connected:
+            return EncryptResult(mode=EncryptMode.DECRYPT, input=input_bytes, result=copy.copy(input_bytes))
+        else:
+            err_msg = "Client is not connected"
+            return EncryptResult(mode=EncryptMode.DECRYPT, input=input_bytes, errors=[str(err_msg)])
+
+    def show_config(self):
+        return "NullEncrypter[no configuration]"
+
+    def close(self):
+        '''No connection or cleanup required for this instance.'''
+        self._is_connected = False
+
+    def is_connected(self):
+        return self._is_connected
+
+
+class EncrypterFactory:
+
+    default_clazz = 'ait.dsn.encrypt.encrypter.NullEncrypter'
+
+    def __init__(self):
+        pass
+
+    @staticmethod
+    def get(encrypter_class_name):
+        '''
+        Returns an instance of an Encrypter, based on kwargs or AIT configuration.
+        If none is specified, then a default implementation that performs no
+        encryption is returned.
+
+        The returned Encryptor has not yet been configured.
+
+        :param kwargs: Keyword argument map with potential key 'encrypter_class_name'
+        :return: New instance of Encrypter
+        :except: ImportError if specified encryption client is not found
+        :except: AitConfigError for errors that occur during configuration
+        '''
+
+        full_class_name = encrypter_class_name
+        lcl_instance = None
+        if encrypter_class_name is None:
+            cfg_class_name = ait.config.get('dsn.encryption.client.name', None)
+            if cfg_class_name:
+                full_class_name = cfg_class_name
+
+        if full_class_name is None:
+            ait.core.log.error(f"No encryption client name specified, using a default")
+            lcl_instance = NullEncrypter()
+        else:
+            try:
+                mod, cls = full_class_name.rsplit('.', 1)
+                lcl_instance = getattr(importlib.import_module(mod), cls)()
+            except ImportError as ie:
+                ait.core.log.error(f"Could not import specified encryption client '{full_class_name}'")
+                raise ie
+
+        return lcl_instance

--- a/ait/dsn/encrypt/kmc_encrypter.py
+++ b/ait/dsn/encrypt/kmc_encrypter.py
@@ -1,0 +1,235 @@
+import datetime as dt
+import itertools
+import math
+import os.path
+import os
+from pathlib import Path
+import json
+
+import ait
+import ait.dsn.util.utils
+from ait.core import cfg, log
+from ait.dsn.encrypt.encrypter import EncryptResult, EncryptMode, BaseEncrypter
+
+# Using these Alias fields to indicate if appropriate respective classes were loaded from KMC third-party import
+KMC_Error_Alias = Exception
+KMC_Class_Alias = None
+try:
+    from gov.nasa.jpl.ammos.kmc.sdlsclient.KmcSdlsClient import KmcSdlsClient, SdlsClientException
+    KMC_Error_Alias = SdlsClientException
+    KMC_Class_Alias = KmcSdlsClient
+except ModuleNotFoundError as mnfer:
+    err_mesg = f"Unable to load the KmcSdlsClient library: {mnfer}"
+    log.error(err_mesg)
+
+"""
+AIT Encryption extension using the MGSS KMC SDLS Encryption client
+
+"""
+
+'''
+Config:
+
+default:
+    dsn:
+        encryption:
+            vcid_filter: [list of vcids for which encryption applies]  (None means all VCIDs included, empty list means No VCID's allowed)
+            client:
+                name: ait.dsn.encrypt.kmc_encrypter.KmcSdlsEncrypter
+                config:
+                    kmc_properties:
+                      - property1=value1  ( or 'property1 = value1' ? or 'property1: value1' ? ) 
+                      - property2=value2
+                         ...
+                      - propertyN=valueN
+                    kmc_property_file: None or location of file
+
+'''
+
+
+class KmcSdlsEncrypter(BaseEncrypter):
+    ''' KMC SDLS Backend Encrypter
+
+    This requires the SdlsClient Python library to be installed and KMC
+    to be installed.
+    '''
+    kmclib_envvar_required = False
+    kmclib_envvar = 'KMC_HOME'
+
+    prop_kmc_properties = 'kmc_properties'
+    prop_kmc_property_file = 'kmc_property_file'
+
+
+    def __init__(self):
+        '''
+        Constructor for KmcSdlsEncrypter
+        '''
+        super().__init__()
+
+        # KMC Client instance
+        self._client = None
+
+        # Points to the KMC properties file (maybe)
+        self._kmc_properties_file = None
+
+        # Newer approach of passing config to client via list
+        self._kmc_config_list = []
+
+    def configure(self, **kwargs):
+        '''
+        Configures this encrypter instance.
+
+        Checks for KMC properties as provided via the kwargs or AIT configuration.
+        :param kwargs: Optional keyword arguments
+        '''
+        super().configure(**kwargs)
+
+        if KmcSdlsEncrypter.kmclib_envvar_required:
+            kmclib_envval = os.environ[KmcSdlsEncrypter.kmclib_envvar]
+            if not kmclib_envval:
+                err_mesg = f"KMC library requires environment variable to be set: {KmcSdlsEncrypter.kmclib_envvar}"
+                log.error(err_mesg)
+                raise cfg.AitConfigError(err_mesg)
+            else:
+                kmclib_path = Path(kmclib_envval)
+                if not kmclib_path.is_dir():
+                    err_mesg = f"KMC library environment variable {KmcSdlsEncrypter.kmclib_envvar} " \
+                               f" is set to a directory that does not exist: {kmclib_path}"
+                    log.error(err_mesg)
+                    raise cfg.AitConfigError(err_mesg)
+
+        # Pull config from the AIT config or keyword args
+        lcl_config_list = kwargs.get(KmcSdlsEncrypter.prop_kmc_properties,
+                                    ait.config.get(
+                                        KmcSdlsEncrypter.cfg_client_config+"."+KmcSdlsEncrypter.prop_kmc_properties, []))
+
+        # May need to format the properties
+        self._kmc_config_list = self.format_config_list(lcl_config_list)
+
+        # KMC-specific properties file
+        kmc_props_file = kwargs.get(KmcSdlsEncrypter.prop_kmc_property_file,
+                             ait.config.get(
+                                 KmcSdlsEncrypter.cfg_client_config+"."+KmcSdlsEncrypter.prop_kmc_property_file, None))
+
+        if kmc_props_file:
+            expanded_props_file = ait.dsn.util.utils.expand_path(kmc_props_file)
+            kmc_props_path = Path(expanded_props_file)
+            if kmc_props_path.is_file():
+                self._kmc_properties_file = expanded_props_file
+            else:
+                err_mesg = f"KMC Properties File does not exist: {kmc_props_file}"
+                log.error(err_mesg)
+                raise cfg.AitConfigError(err_mesg)
+
+        if self._debug_enabled:
+            log.info(f"KmcSdlsEncrypter: KMC property list is: {self._kmc_config_list}")
+            log.info(f"KmcSdlsEncrypter: KMC property file is: {self._kmc_properties_file}")
+
+    def connect(self):
+        '''
+            Connect to an KMC SDSL service instance
+            During the configure() step, configuration information was retrieved.
+            If properties file was provided, then it will be used.
+            Else the property list (potentially empty) will be used.
+
+            :except: SdlsClientException if SDLS Client error occurs
+            :except: Exception if other error occurs
+        '''
+
+        # Current attempt at checking if KMC library was loaded, probably something better out there
+        if KMC_Class_Alias is None:
+            err_mesg = f"KmcSdlsClient library was not loaded"
+            log.error(err_mesg)
+            return
+
+        try:
+            if self._kmc_properties_file:
+                self._client = KmcSdlsClient(self._kmc_properties_file)
+            else:
+                self._client = KmcSdlsClient(self._kmc_config_list)
+        except KMC_Error_Alias as scex:
+            log.error(f"SDLS Client Error occurred while instantiating KMC Client: '{scex}'")
+            raise scex
+        except Exception as ex:
+            log.error(f"Error occurred while instantiating KMC Client: '{ex}'")
+            raise ex
+
+    def encrypt(self, input_bytes):
+        ''' Encrypts a byte-array using the KMC Encrypter
+
+            :param: input_bytes Original byte-array to be encrypted
+            :returns: EncryptResult object with result or errors
+        '''
+
+        if not self._client:
+            err_msg = "KMC SDLS Client is not connected"
+            return EncryptResult(mode=EncryptMode.ENCRYPT, input=input_bytes, errors=[str(err_msg)])
+
+        try:
+            output_bytes = self._client.apply_security_tc(input_bytes)
+            return EncryptResult(mode=EncryptMode.ENCRYPT, input=input_bytes, result=output_bytes)
+        except SdlsClientException as sc_ex:
+            return EncryptResult(mode=EncryptMode.ENCRYPT, input=input_bytes, errors=[str(sc_ex)])
+
+    def decrypt(self, input_bytes):
+        ''' Decrypts a byte-arrauy using the KMC Encryption client
+
+            :param: input_bytes Original byte-array to be decrypted
+            :returns: EncryptResult object with result or errors
+        '''
+
+        if not self._client:
+            err_msg = "KMC SDLS Client is not connected"
+            return EncryptResult(mode=EncryptMode.DECRYPT, input=input_bytes, errors=[str(err_msg)])
+
+        try:
+
+            # process_security_tc() returns:
+            #        class TC(NamedTuple):
+            #            tc_header: TC_FramePrimaryHeader
+            #            tc_security_header: TC_FrameSecurityHeader
+            #            tc_pdu: bytearray  (the decrypted payload)
+            #            tc_security_trailer: TC_FrameSecurityTrailer
+
+            tc_result = self._client.process_security_tc(input_bytes)
+            if tc_result.tc_pdu is None:
+                tc_err_msg = "Decryption returned with empty result"
+                return EncryptResult(mode=EncryptMode.DECRYPT, input=input_bytes, errors=[tc_err_msg])
+            else:
+                output_bytes = tc_result.tc_pdu
+                return EncryptResult(mode=EncryptMode.DECRYPT, input=input_bytes, result=output_bytes)
+
+        except SdlsClientException as sc_ex:
+            return EncryptResult(mode=EncryptMode.DECRYPT, input=input_bytes, errors=[str(sc_ex)])
+
+    def show_config(self):
+        '''
+        Return encrypter name and associated configuration
+        :return:
+        '''
+        if self._client:
+            if self._kmc_properties_file:
+                return f"KmcSdlsEncrypter[property_file: {self._kmc_properties_file}]"
+            elif self._kmc_config_list:
+                return f"KmcSdlsEncrypter[property_list: {self._kmc_config_list}]"
+            else:
+                return "KmcSdlsEncrypter[no configuration]"
+
+    def close(self):
+        '''
+        Release the reference to the KMC client
+        '''
+        if self._client:
+            self._client = None
+
+    def is_connected(self):
+        return self._client is not None
+
+    def format_config_list(self, cfg_list):
+        '''
+        Applies formatting to the incoming list of configuration properties
+        :param cfg_list: Input config list
+        :return: Possibly formatted version of config list
+        '''
+        # As of now, we don't do anything special, but stay tuned...
+        return cfg_list

--- a/ait/dsn/encrypt/test/test_encrypt.py
+++ b/ait/dsn/encrypt/test/test_encrypt.py
@@ -1,0 +1,162 @@
+# Advanced Multi-Mission Operations System (AMMOS) Instrument Toolkit (AIT)
+# Bespoke Link to Instruments and Small Satellites (BLISS)
+#
+# Copyright 2016, by the California Institute of Technology. ALL RIGHTS
+# RESERVED. United States Government Sponsorship acknowledged. Any
+# commercial use must be negotiated with the Office of Technology Transfer
+# at the California Institute of Technology.
+#
+# This software may be subject to U.S. export control laws. By accepting
+# this software, the user agrees to comply with all applicable U.S. export
+# laws and regulations. User has the responsibility to obtain export licenses,
+# or other export authority as may be required before exporting such
+# information to foreign countries or providing access to foreign persons.
+
+import datetime as dt
+import inspect
+import os
+import unittest
+import binascii
+
+import nose.tools
+from unittest import mock
+
+import ait.core.cfg as cfg
+import ait.core.db as db
+import ait.core.dmc as dmc
+import ait.core.tlm as tlm
+from ait.dsn.encrypt.encrypter import EncryptMode, EncryptResult, EncrypterFactory, NullEncrypter
+
+
+tc4_1_hexstr =  "2003009e00ff000100001880d037008c197f0b000100840000344892bbc54f5395297d4c371" \
+                "72f2a3c46f6a81c1349e9e26ac80985d8bbd55a5814c662e49fba52f99ba09558cd21cf268b" \
+                "8e50b2184137e80f76122034c580464e2f06d2659a50508bdfe9e9a55990ba4148af896d8a6" \
+                "eebe8b5d2258685d4ce217a20174fdd4f0efac62758c51b04e55710a47209c923b641d19a39" \
+                "001f9e986166f5ffd95555"
+## tc4_1_bytes = bytes.fromhex(tc4_1_hexstr)
+tc4_1_byte_arr = bytearray(binascii.unhexlify(tc4_1_hexstr))
+
+class TestEncryptResultObject(unittest.TestCase):
+    def test_default_init(self):
+        res = EncryptResult()
+        assert res.input is None
+        assert res.result is None
+        assert res.errors is None
+        assert res.mode == EncryptMode.ENCRYPT
+
+        input = 'foobar'
+        result = [1, 2, 3]
+        errors = ['error1', 'error2']
+        res = EncryptResult(input=input, result=result, errors=errors)
+        assert res.input == input
+        assert res.result == result
+        assert res.errors == errors
+        assert res.mode == EncryptMode.ENCRYPT
+
+        res = EncryptResult(mode=EncryptMode.DECRYPT, input=input, result=result, errors=errors)
+        assert res.input == input
+        assert res.result == result
+        assert res.errors == errors
+        assert res.mode == EncryptMode.DECRYPT
+
+class TestFactory(unittest.TestCase):
+    def test_factory(self):
+
+        encr = EncrypterFactory().get()
+        assert isinstance(encr, NullEncrypter)
+
+        null_classname = "ait.dsn.encrypt.encrypter.NullEncrypter"
+        invalid_classname = "i.do.not.exist"
+
+        encr = EncrypterFactory().get(null_classname)
+        assert isinstance(encr, NullEncrypter)
+
+        with nose.tools.assert_raises(ImportError):
+            EncrypterFactory().get(invalid_classname)
+
+class TestNullEncrypter(unittest.TestCase):
+    def test_null_encrypter(self):
+        encr_clz = 'ait.dsn.encrypt.encrypter.NullEncrypter'
+        encr = EncrypterFactory().get(encr_clz)
+        assert isinstance(encr, NullEncrypter)
+        assert not encr.is_connected()
+
+        # encrypt should fail since not connected generally, but not for Null
+        ait_result = encr.encrypt(tc4_1_byte_arr)
+        assert ait_result.has_errors
+
+        encr.configure()
+        assert not encr.is_connected()
+        assert not encr._debug_enabled
+        assert encr._vcids_filter is None
+
+        vcid_list = [3, 6, 9]
+        enc_cfg = {'vcid_filter': vcid_list, 'debug_enabled' : True}
+        encr.configure(**enc_cfg)
+        assert encr._debug_enabled
+        assert encr._vcids_filter == vcid_list
+
+        ait_result = encr.encrypt(tc4_1_byte_arr)
+        assert ait_result.has_errors
+
+        encr.connect()
+        assert encr.is_connected()
+
+        ait_result = encr.encrypt(tc4_1_byte_arr)
+        assert ait_result.mode == EncryptMode.ENCRYPT
+        assert not ait_result.has_errors
+        assert ait_result.has_result
+        assert ait_result.result == tc4_1_byte_arr
+
+        ait_result = encr.decrypt(tc4_1_byte_arr)
+        assert ait_result.mode == EncryptMode.DECRYPT
+        assert not ait_result.has_errors
+        assert ait_result.has_result
+        assert ait_result.result == tc4_1_byte_arr
+
+        encr.close()
+        assert not encr.is_connected()
+        ait_result = encr.encrypt(tc4_1_byte_arr)
+        assert ait_result.has_errors
+
+
+class TestKmcEncrypter(unittest.TestCase):
+    '''
+    Unit test assumes we cannot load the KMC Encrypter dependencies
+    '''
+    def test_kmc_encrypter(self):
+        encr_mod_name = 'ait.dsn.encrypt.kmc_encrypter'
+        encr_clz_name = 'KmcSdlsEncrypter'
+        encr_full_clz = encr_mod_name + "." + encr_clz_name
+        encr = EncrypterFactory().get(encr_full_clz)
+
+        assert type(encr).__name__ == encr_clz_name
+
+        # encrypt should fail since not configured nor connected
+        ait_result = encr.encrypt(tc4_1_byte_arr)
+        assert ait_result.mode == EncryptMode.ENCRYPT
+        assert ait_result.has_errors
+
+        encr.configure()
+        ait_result = encr.encrypt(tc4_1_byte_arr)
+        assert ait_result.mode == EncryptMode.ENCRYPT
+        assert ait_result.has_errors
+
+        # Failed import of KMC lib results in a Name error
+        #with nose.tools.assert_raises(NameError):
+        #    encr.connect()
+        encr.connect()
+        assert not encr.is_connected()
+
+        ait_result = encr.encrypt(tc4_1_byte_arr)
+        assert ait_result.mode == EncryptMode.ENCRYPT
+        assert ait_result.has_errors
+
+
+        ait_result = encr.decrypt(tc4_1_byte_arr)
+        assert ait_result.mode == EncryptMode.DECRYPT
+        assert ait_result.has_errors
+
+        encr.close()
+        ait_result = encr.encrypt(tc4_1_byte_arr)
+        assert ait_result.has_errors

--- a/ait/dsn/util/__init__.py
+++ b/ait/dsn/util/__init__.py
@@ -1,0 +1,13 @@
+# Advanced Multi-Mission Operations System (AMMOS) Instrument Toolkit (AIT)
+# Bespoke Link to Instruments and Small Satellites (BLISS)
+#
+# Copyright 2017, by the California Institute of Technology. ALL RIGHTS
+# RESERVED. United States Government Sponsorship acknowledged. Any
+# commercial use must be negotiated with the Office of Technology Transfer
+# at the California Institute of Technology.
+#
+# This software may be subject to U.S. export control laws. By accepting
+# this software, the user agrees to comply with all applicable U.S. export
+# laws and regulations. User has the responsibility to obtain export licenses,
+# or other export authority as may be required before exporting such
+# information to foreign countries or providing access to foreign persons.

--- a/ait/dsn/util/utils.py
+++ b/ait/dsn/util/utils.py
@@ -1,0 +1,45 @@
+# Advanced Multi-Mission Operations System (AMMOS) Instrument Toolkit (AIT)
+#
+# Copyright 2021, by the California Institute of Technology. ALL RIGHTS
+# RESERVED. United States Government Sponsorship acknowledged. Any
+# commercial use must be negotiated with the Office of Technology Transfer
+# at the California Institute of Technology.
+#
+# This software may be subject to U.S. export control laws. By accepting
+# this software, the user agrees to comply with all applicable U.S. export
+# laws and regulations. User has the responsibility to obtain export licenses,
+# or other export authority as may be required before exporting such
+# information to foreign countries or providing access to foreign persons.
+
+import os
+
+_ROOT_DIR = os.path.abspath(os.environ.get('AIT_ROOT', os.getcwd()))
+
+# Why DSN has it's own function when something similar is in AIT-Core?
+# Well, the latter does not expand envVars, which I would like to support.
+
+def expand_path(path):
+    '''
+    Expands path value to replace home-dir (~), environment variables,
+    and returns an absolute path.  If path is relative, then the parent
+    directory is presumed to be the AIT_ROOT envVar, or if not set,
+    the current working directory
+    :param path: Path to be expanded
+    :return: Absolute, expanded path
+    '''
+    expanded = path
+
+    # Check for ~ or relative-paths
+    if expanded[0] == '~':
+        expanded = os.path.expanduser(expanded)
+
+    # Expand any envvars in the path
+    expanded = os.path.expandvars(expanded)
+
+    if expanded[0] != '/':
+        expanded = os.path.join(_ROOT_DIR, expanded)
+
+    # Return the absolute path
+    expanded = os.path.abspath(expanded)
+
+    return expanded

--- a/doc/source/ait.dsn.bin.ait_encrypt.rst
+++ b/doc/source/ait.dsn.bin.ait_encrypt.rst
@@ -1,0 +1,7 @@
+ait.dsn.bin.ait\_encrypt module
+===================================
+
+.. automodule:: ait.dsn.bin.ait_encrypt
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/doc/source/ait.dsn.bin.rst
+++ b/doc/source/ait.dsn.bin.rst
@@ -10,6 +10,7 @@ Submodules
    ait.dsn.bin.ait_cfdp_start_sender
    ait.dsn.bin.ait_sle_bridge
    ait.dsn.bin.ait_sle_interface_manager
+   ait.dsn.bin.ait_encrypt
 
 Module contents
 ---------------

--- a/doc/source/ait.dsn.encrypt.encrypter.rst
+++ b/doc/source/ait.dsn.encrypt.encrypter.rst
@@ -1,0 +1,11 @@
+ait.dsn.encrypt.encrypter package
+===================================
+
+
+Module contents
+---------------
+
+.. automodule:: ait.dsn.encrypt.encrypter
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/doc/source/ait.dsn.encrypt.kmc_encrypter.rst
+++ b/doc/source/ait.dsn.encrypt.kmc_encrypter.rst
@@ -1,0 +1,11 @@
+ait.dsn.encrypt.kmc_encrypter package
+=======================================
+
+
+Module contents
+---------------
+
+.. automodule:: ait.dsn.encrypt.kmc_encrypter
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/doc/source/ait.dsn.encrypt.rst
+++ b/doc/source/ait.dsn.encrypt.rst
@@ -1,0 +1,18 @@
+ait.dsn.encrypt package
+=========================
+
+Submodules
+----------
+
+.. toctree::
+
+   ait.dsn.encrypt.encrypter
+   ait.dsn.encrypt.kmc_encrypter
+
+Module contents
+---------------
+
+.. automodule:: ait.dsn.encrypt
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/doc/source/ait.dsn.rst
+++ b/doc/source/ait.dsn.rst
@@ -9,7 +9,9 @@ Subpackages
     ait.dsn.bch
     ait.dsn.bin
     ait.dsn.cfdp
+    ait.dsn.encrypt
     ait.dsn.sle
+    ait.dsn.util
 
 Module contents
 ---------------

--- a/doc/source/ait.dsn.util.rst
+++ b/doc/source/ait.dsn.util.rst
@@ -1,0 +1,14 @@
+ait.dsn.util module
+========================
+
+Submodules
+----------
+
+.. toctree::
+
+   ait.dsn.util.utils
+
+.. automodule:: ait.dsn.util
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/doc/source/ait.dsn.util.utils.rst
+++ b/doc/source/ait.dsn.util.utils.rst
@@ -1,0 +1,7 @@
+ait.dsn.util.utils module
+========================
+
+.. automodule:: ait.dsn.util.utils
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/doc/source/command_line.rst
+++ b/doc/source/command_line.rst
@@ -1,0 +1,18 @@
+Command Line Utilities
+======================
+
+AIT provides some command line utilities for performing common operations. Below is a breakdown of these utilities with a brief explanation of how they work and why you might use them.
+
+----
+
+
+Encryption Utilities
+----------------------
+
+Utilities for the encryption and decryption.
+
+ait-encrypt
+^^^^^^^^^^^^^^^^
+.. literalinclude:: ../../ait/dsn/bin/ait_encrypt.py
+   :start-after: '''
+   :end-before: '''

--- a/doc/source/encryption.rst
+++ b/doc/source/encryption.rst
@@ -1,0 +1,190 @@
+AIT Encryption
+================
+
+This guide covers AIT's encryption support as provided by the AIT-DSN repository.
+
+AIT offers an encryption API with some supported implementations, and to which extensions can be added.
+The default implementation, NullEncrypter, supports the API but performs no encryption/decryption.
+
+For projects which utilize the MGSS KMC SDLS Encryption service, AIT offers a wrapper for that service, KmcSdlsEncrypter.
+
+Encryption is currently limited to support command uplink (TC Frames), though may be expanded for downlink at some future date.
+
+
+
+Configuration
+^^^^^^^^^^^^^
+
+The necessary configuration parameters can be added to the **config.yaml**; under 'dsn:encryption'.
+Optionally, many of the same parameters can also be passed in at runtime as keyword arguments for greater flexibility.
+Below is an example configuration which can be used as a reference, in addition to the default configuration available in the repository.
+
+
+::
+
+    dsn:
+        encryption:
+            vcid_filter: [list of vcids for which encryption applies]  #None means all VCIDs included, empty list means No VCID's allowed)
+            client:
+                name: ait.dsn.encrypt.module.class
+                config:
+                    <client-specific-config, parsed by implementation>
+
+
+
+An *example* of the configuration that uses the KMC SDLS encrypter (configured to use Cryptolib) is:
+
+::
+
+    dsn:
+        encryption:
+            vcid_filter: None
+            client:
+                name: ait.dsn.encrypt.kmc_encrypter.KmcSdlsEncrypter
+                config:
+                    kmc_properties:
+                      - cryptolib.sadb.type=inmemory
+                      - cryptolib.crypto.type=libgcrypt
+                      - cryptolib.process_tc.ignore_antireplay=true
+                      - cryptolib.process_tc.ignore_sa_state=true
+                      - cryptolib.process_tc.process_pdus=false
+                      - cryptolib.tc.vcid_bitmask=0x3F
+                      - cryptolib.tc.3.0.has_segmentation_header=true
+                      - cryptolib.tc.3.0.has_pus_header=true
+                      - cryptolib.tc.3.0.has_ecf=true
+                      - cryptolib.tc.3.0.max_frame_length=1024
+                    kmc_property_file: None
+
+
+Note: The KMC-encrypter supports either the *kmc_properties* list or a single *kmc_property_file*, but not both.
+If both are specified, and the value of the *kmc_property_file* points to a file that exists, the file will be used.
+Else the properties will be used.
+
+Note: For the *proper* set of kmc_properties to include for your particular environment, please contact your GDS or KMC-deployment representative.
+
+
+Using the Encryption API
+^^^^^^^^^^^^^^^^^^^^^^^^
+
+First, an encrypter instance must be created.  AIT provides a factory that instantiates the encrypter instance.
+The factory can be provided with the full classname of the desired instance, or rely on the AIT config.
+If no class is specified in either case, then the default implementation returned will be the NullEncrypter.
+
+::
+
+    # Import the encrypter module
+    from ait.dsn.encrypt.encrypter import EncryptMode, EncryptResult, EncrypterFactory, BaseEncrypter
+
+    # 1) Rely on AIT configuration for encrypter instance, or return default
+    encrypter = EncrypterFactory().get()
+
+    # ...or 2) Specify the desired class to be used via argument
+    encrypter_cls = 'extended.encryption.module.class'
+    encrypter = EncrypterFactory().get(encrypter_cls)
+
+
+Next, the instance must be configured and connected.
+
+By default, configuration can rely solely on the AIT config. The Encrypter API supports keyword arguments for the configure() method, which would override values specified in the AIT config.
+
+::
+
+    # Configure, rely solely on AIT config
+    encrypter.configure()
+
+    # ...or configure passing in keyword arguments, will override AIT config
+    encrypter.configure(**kwargs)
+
+    # Connect the instance
+    encrypter.connect()
+
+
+Now the encrypter instance can be used to encrypt and decrypt *bytearrays* .
+
+::
+
+    in_bytearray = bytearray(input_bytes)
+    out_bytes = None
+
+    # For encryption
+    crypt_result = encrypter.encrypt(in_bytearray)
+
+    # - or -
+
+    # For decryption
+    crypt_result = encrypter.decrypt(in_bytearray)
+
+    if crypt_result.has_errors:
+        for e in ait_result.errors:
+            ait.core.log.error(f"Error occurred during processing {e}")
+    elseif crypt_result.has_result:
+        out_bytearray = ait_result.result
+        out_bytes = bytes(out_bytearray)
+
+
+When processing is complete, you can close the encrypter instance:
+
+::
+
+    # Close the encrypter, releasing any resources
+    encrypter.close()
+
+
+Setting up your environment for MGSS KMC SDSL Client
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+MGSS provides the KMC SDLS client for which AIT offers a wrapper.
+
+The KMC client should already have been installed in your environment.
+Otherwise, you may install it locally via an expanded tar-ball distribution.
+In either situation, the client contains shared libraries and Python wrappers.
+
+Notes
+-----
+
+- Configuration of the KMC client falls outside the scope of this document.  Please refer to your GDS rep.
+
+- While AIT typically recommends Python 3.7, MGSS is currently supporting only Python 3.6, 3.8 and 3.9.  As such, we recommend users switch to Python 3.8 for combined AIT tools and KMC Client. No compatibility issues have been found using this version, thus far.
+
+Environment Variables Setup
+---------------------------
+
+AIT continues to recommend the usage of virtual environments when using its tools.
+However, further manual steps are required to ensure that AIT can find and load the KMC client.
+Below are setup steps used to integrate this client with your AIT repository.
+
+We recommend that these steps be captured in a environment setup script.
+
+::
+
+    # Set some environment variables pointing to your expanded KMC tarball
+    setenv KMC_CLIENT_HOME /path/to/installed/kmc/client/
+    setenv KMC_PYTHON_VERSION python3.8
+
+    setenv LD_LIBRARY_PATH ${KMC_CLIENT_HOME}/lib/:${LD_LIBRARY_PATH}
+    setenv PYTHONPATH ${KMC_CLIENT_HOME}/lib/${KMC_PYTHON_VERSION}/site-packages/
+
+From this point, the AIT KMC wrapper should be able to load all libraries and Python modules.
+
+
+Check Installation
+------------------
+
+Now that your installation has finished let's check that everything works as expected.
+
+.. code-block:: bash
+
+   # Test that you can properly import the KMC client package.
+   > python -c "import gov.nasa.jpl.ammos.kmc.sdlsclient.KmcSdlsClient"
+
+If the last command **doesn't** generate any errors your installation is all set!
+
+If you see an error as shown below make sure to activate your virtual environment first, and set the required environment variables.
+
+.. code-block:: bash
+
+   > python -c "import gov.nasa.jpl.ammos.kmc.sdlsclient.KmcSdlsClient"
+    Traceback (most recent call last):
+      File "<string>", line 1, in <module>
+    ModuleNotFoundError: No module named 'gov.nasa.jpl.ammos.kmc.sdlsclient.KmcSdlsClient'
+

--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -23,6 +23,8 @@ Table of Contents:
    ait_cfdp
    sle
    ait_sle
+   encryption
+   command_line
    AIT DSN API Documentation <ait>
 
 


### PR DESCRIPTION

AIT now offers an encryption API with some supported implementations, and to which extensions can be added.
The default implementation, NullEncrypter, supports the API but performs no encryption/decryption.

For projects which utilize the MGSS KMC SDLS Encryption service, AIT offers a wrapper for that service, KmcSdlsEncrypter.

Encryption is currently limited to support command uplink (TC Frames), though may be expanded for downlink at some future date.

This PR supports a schedule engineering release of the AIT Encryption API for use by SunRise.

General documentation is available here: https://github.com/NASA-AMMOS/AIT-DSN/blob/issue-140/doc/source/encryption.rst

__________________________

Included is a new command-line tool ait_encrypt, which allows the binary contents of a file to be encrypted and decrypted using available encrypter classes:

```
usage: ait_encrypt.py [-h] --mode {encrypt,decrypt} --type TYPE --input INPUT 
                      [--output OUTPUT] [--verbose]

Performs encryption or decryption on bytes from a file.

optional arguments:
  -h, --help            show this help message and exit
  --mode {encrypt,decrypt}
                        Mode: 'encrypt', 'decrypt' (default: encrypt)
  --type TYPE           Type of encrypter to use: 'null', 'kmc'; or full class name
                        (default: null)
  --input INPUT         Input filename, required. (default: None)
  --output OUTPUT       Output filename, optional. (default: None)
  --verbose             Print debug messages. (default: False)
  
Examples:

  $ ait_encrypt --mode encrypt --type null --input input.bin  --output output.bin
  $ ait_encrypt --mode decrypt --type null --input output.bin --output restored.bin
```
  
__________________________

Fixes #140 
