### PR TITLE
Issue #169  Add select/sendall when using DSN socket

### DIFF
--- a/ait/dsn/sle/common.py
+++ b/ait/dsn/sle/common.py
@@ -57,6 +57,7 @@ import time
 import gevent
 import gevent.queue
 import gevent.socket
+import gevent.select
 import gevent.monkey; gevent.monkey.patch_all()
 
 import pyasn1.error
@@ -161,7 +162,9 @@ class SLE(object):
     def send(self, data):
         ''' Send supplied data to DSN '''
         try:
-            self._socket.send(data)
+            _, writeable, _ = gevent.select([], [self._socket], [])
+            for i in writeable:
+                i.sendall(data)
         except socket.error as e:
             if e.errno == errno.ECONNRESET:
                 ait.core.log.error('Socket connection lost to DSN')


### PR DESCRIPTION
+ AIT DSN produces E22 Broken Pipe error while uploading multiple TCTFs using DSN interface.
+ Use socket correctly by using select/sendall