### PR TITLE
Issue #174 - Fix gevent.select typo

### DIFF
--- a/ait/dsn/sle/common.py
+++ b/ait/dsn/sle/common.py
@@ -162,7 +162,7 @@ class SLE(object):
     def send(self, data):
         ''' Send supplied data to DSN '''
         try:
-            _, writeable, _ = gevent.select([], [self._socket], [])
+            _, writeable, _ = gevent.select.select([], [self._socket], [])
             for i in writeable:
                 i.sendall(data)
         except socket.error as e:


### PR DESCRIPTION
Fix gevent.select typo

Should be gevent.select.select 

Will try to call module otherwise