### PR TITLE
Issue #176 - Fix typo in AOS_to_CCSDS

### DIFF
--- a/ait/dsn/plugins/AOS_to_CCSDS.py
+++ b/ait/dsn/plugins/AOS_to_CCSDS.py
@@ -13,9 +13,8 @@ class AOS_to_CCSDS(Plugin):
 
     def process(self, data, topic=None):
         AOS_frame_object = AOSTransFrame(data)
-        if AOS_frame_object.is_idle_frame or
-        not AOS_frame_object.get('aos_data_field_type') ==
-        AOSDataFieldType.M_PDU:
+        if AOS_frame_object.is_idle_frame or \
+           AOS_frame_object.get('aos_data_field_type') is not AOSDataFieldType.M_PDU:
             log.debug(f"Dropping idle frame!")
             return
         else:

--- a/doc/source/AOS_to_CCSDS.rst
+++ b/doc/source/AOS_to_CCSDS.rst
@@ -9,41 +9,43 @@ config.yaml snippet:
 
 .. code-block:: none
 
-sle:
-  frame_output_port: 2568
+   sle:
+       frame_output_port: 2568
 
   
 Since the DSN interface does not publish to the PUB/SUB network,
 you will need to configure a UDP port to loop the frame back into AIT.
 
 .. code-block:: none
-				
+                
    - stream:
-	   name: telemetry_stream
-       input: 
-           - 2568
+         name: telemetry_stream
+         input: 
+             - 2568
 
 Next, the AOS configuration must be added, as shown in the example below.
+
 .. code-block:: none
 
-		dsn:
-			sle:
-				aos:
-				    frame_header_error_control_included: false
-                    transfer_frame_insert_zone_len: 0
-                    operational_control_field_included: false
-                    frame_error_control_field_included: false
-                    virtual_channels:
-                        1: "m_pdu"
-                        2: "m_pdu"
-                        4: "m_pdu"
-                       63: "idle"
+   dsn:
+       sle:
+           aos:
+               frame_header_error_control_included: false
+               transfer_frame_insert_zone_len: 0
+               operational_control_field_included: false
+               frame_error_control_field_included: false
+               virtual_channels:
+                   1: "m_pdu"
+                   2: "m_pdu"
+                   4: "m_pdu"
+                   63: "idle"
 
-					   
+                       
 Finally, the AOS_to_CCSDS must be configured.
+
 .. code-block:: none
 
-            - plugin:
-                name: ait.dsn.plugins.AOS_to_CCSDS.AOS_to_CCSDS
-                inputs:
-                    - telemetry_stream
+   - plugin:
+       name: ait.dsn.plugins.AOS_to_CCSDS.AOS_to_CCSDS
+       inputs:
+           - telemetry_stream


### PR DESCRIPTION
https://github.com/NASA-AMMOS/AIT-DSN/blob/8355928e6a85cf4efc3ed13e3355d8e1ef218f85/ait/dsn/plugins/AOS_to_CCSDS.py#L17

Is missing a line continuation slash.

Should be: 

`if AOS_frame_object.is_idle_frame or \
           AOS_frame_object.get('aos_data_field_type') is not AOSDataFieldType.M_PDU:`

Fix additional typos in rst documentation.

Fixes #176