### PR TITLE
Issue #188 - Fix readthedocs build for DSN

### DIFF
--- a/doc/source/ait.dsn.bin.ait_sle_bridge.rst
+++ b/doc/source/ait.dsn.bin.ait_sle_bridge.rst
@@ -1,7 +1,0 @@
-ait.dsn.bin.ait\_sle\_bridge module
-===================================
-
-.. automodule:: ait.dsn.bin.ait_sle_bridge
-    :members:
-    :undoc-members:
-    :show-inheritance:

--- a/doc/source/ait.dsn.bin.rst
+++ b/doc/source/ait.dsn.bin.rst
@@ -8,8 +8,6 @@ Submodules
 
    ait.dsn.bin.ait_cfdp_mock_server
    ait.dsn.bin.ait_cfdp_start_sender
-   ait.dsn.bin.ait_sle_bridge
-   ait.dsn.bin.ait_sle_interface_manager
    ait.dsn.bin.ait_encrypt
 
 Module contents

--- a/doc/source/ait.dsn.plugins.vcid_routing.rst
+++ b/doc/source/ait.dsn.plugins.vcid_routing.rst
@@ -1,7 +1,7 @@
-ait.core.plugins.vcid_routing module
+ait.dsn.plugins.vcid_routing module
 ======================================
 
-.. automodule:: ait.core.plugins.vcid_routing
+.. automodule:: ait.dsn.plugins.vcid_routing
    :members:
    :undoc-members:
    :show-inheritance:

--- a/doc/source/ait.dsn.sle.util.sle_interface_manager.rst
+++ b/doc/source/ait.dsn.sle.util.sle_interface_manager.rst
@@ -1,5 +1,5 @@
 ait.dsn.bin.ait\_sle\_interface\_manager Module
 ===============================================
 
-.. autobottle:: ait.dsn.bin.ait_sle_interface_manager:SLEInterfaceManager().api
+.. autobottle:: ait.dsn.sle.util.sle_interface_manager:SLEInterfaceManager().api
    :include-empty-docstring:

--- a/doc/source/ait.dsn.sle.util.sle_interface_mgr_server.rst
+++ b/doc/source/ait.dsn.sle.util.sle_interface_mgr_server.rst
@@ -1,0 +1,7 @@
+ait.dsn.sle.util.sle\_interface\_mgr\_server Module
+===============================================
+
+.. automodule:: ait.dsn.sle.util.sle_interface_mgr_server
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -12,6 +12,10 @@
 # All configuration values have a default; values that are commented out
 # serve to show the default.
 
+import gevent
+import gevent.monkey
+gevent.monkey.patch_all()
+
 import sys
 import os
 

--- a/doc/source/encryption.rst
+++ b/doc/source/encryption.rst
@@ -161,7 +161,7 @@ We recommend that these steps be captured in a environment setup script.
     ## Without this, we get error along lines of:
     ## /lib64/libk5crypto.so.3: undefined symbol: EVP_KDF_ctrl, version OPENSSL_1_1_1b
     ## ..when loading the KMC Client.
-    set LD_PRELOAD_LIB = /usr/lib64/libcrypto.so.1.1
+    setenv LD_PRELOAD = /usr/lib64/libcrypto.so.1.1
 
 From this point, the AIT KMC wrapper should be able to load all libraries and Python modules.
 


### PR DESCRIPTION
To resolve a recursion error when DMC loads the leapseconds file, we have to monkey-patch Sphinx, and this is done via adding that to the conf.py file

Also made some minor updates to a few RST files to get rid of some of the warnings.

Proof of successful build: https://readthedocs.org/projects/ait-dsn/builds/17471758/

Fixes #188 