### PR TITLE
Issue #200 - Move SLE class vars to instance vars

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ with io.open(path.join(here, 'README.rst'), encoding='utf-8') as f:
 
 setup(
     name = 'ait-dsn',
-    version = '2.0.1-rc1',
+    version = '2.0.2',
     description  = description,
     long_description = long_description,
     long_description_content_type = 'text/x-rst',


### PR DESCRIPTION
When running more than one class that inherits from SLE, `_state`, `_handlers`, `_data_queue`, and `_invoke_id` become shared. The most common issue this creates is if data is being inserted into the data queue that is being shared. Data will be given to any of the children even if the PDU does not match what the child knows about.

By making these instance level attributes data is kept confined to the individual member and is not shared.

Additionally, if a socket is closed abruptly, the _state should be reset to "unbound" because the only way to reset it would be to destroy the object.

patch_all is not required as the only thing being monkey patched for gevents is time. By running patch_all, issues arise when running non-gevent queues in calling applications.

`_telem_sock` should only be created when connecting, not on class instantiation

Running the same workflow as defined in the issue ticket the output is now
```
2022-12-07T15:08:31.652 | INFO     | Starting conn monitor for <class 'ait.dsn.sle.raf.RAF'>
2022-12-07T15:08:31.652 | INFO     | Configuring SLE connection...
2022-12-07T15:08:31.653 | INFO     | SLE connection configuration successful
2022-12-07T15:08:31.653 | INFO     | Sending Bind request ...
<class 'ait.dsn.sle.raf.RAF'>
2022-12-07T15:08:31.657 | INFO     | Bind successful
2022-12-07T15:08:32.655 | INFO     | Sending data start invocation ...
<class 'ait.dsn.sle.raf.RAF'>
2022-12-07T15:08:32.660 | INFO     | Start successful
<class 'ait.dsn.sle.raf.RAF'>
2022-12-07T15:08:33.669 | INFO     | Connection to DSN successful through localhost.
2022-12-07T15:08:33.669 | INFO     | Starting conn monitor for <class 'ait.dsn.sle.cltu.CLTU'>
2022-12-07T15:08:33.669 | INFO     | Configuring SLE connection...
2022-12-07T15:08:33.669 | INFO     | SLE connection configuration successful
2022-12-07T15:08:33.670 | INFO     | Sending Bind request ...
<class 'ait.dsn.sle.cltu.CLTU'>
2022-12-07T15:08:33.674 | INFO     | Bind successful
<class 'ait.dsn.sle.raf.RAF'>
2022-12-07T15:08:34.674 | INFO     | Sending data start invocation ...
<class 'ait.dsn.sle.cltu.CLTU'>
2022-12-07T15:08:34.679 | INFO     | Start Successful
<class 'ait.dsn.sle.raf.RAF'>
<class 'ait.dsn.sle.raf.RAF'>
<class 'ait.dsn.sle.raf.RAF'>
```
Which demonstrates that all frames received on 5307 are correctly being sent to the RAF queue.

Fixes #200